### PR TITLE
fix: do not force to build on production

### DIFF
--- a/src/deploy/actions.spec.ts
+++ b/src/deploy/actions.spec.ts
@@ -15,18 +15,35 @@ const PROJECT = 'pirojok-project';
 describe('Deploy Angular apps', () => {
   beforeEach(() => initMocks());
 
-  xit('should invoke the builder', async () => {
-    const spy = spyOn(context, 'scheduleTarget').and.callThrough();
-    await deploy(mockEngine, context, 'host', {});
+  describe('Builder', () => {
+    let spy: jest.SpyInstance;
 
-    expect(spy).toHaveBeenCalledWith(
-      {
+    beforeEach(() => {
+      spy = jest.spyOn(context, 'scheduleTarget');
+    });
+
+    it('should invoke the builder', async () => {
+      await deploy(mockEngine, context, 'host', {});
+
+      expect(spy).toHaveBeenCalledWith({
         target: 'build',
-        configuration: 'production',
         project: PROJECT
-      },
-      {}
-    );
+      });
+    });
+
+    it('should invoke the builder with the right configuration', async () => {
+      const customConf = 'my-custom-conf';
+
+      await deploy(mockEngine, context, 'host', {
+        configuration: customConf
+      });
+
+      expect(spy).toHaveBeenCalledWith({
+        target: 'build',
+        project: PROJECT,
+        configuration: customConf
+      });
+    });
   });
 
   it('should invoke engine.run', async () => {

--- a/src/deploy/actions.ts
+++ b/src/deploy/actions.ts
@@ -1,5 +1,5 @@
-import { BuilderContext } from '@angular-devkit/architect';
-import { json, logging } from '@angular-devkit/core';
+import { BuilderContext, Target } from '@angular-devkit/architect';
+import { logging } from '@angular-devkit/core';
 
 import { Schema } from './schema';
 
@@ -21,17 +21,25 @@ export default async function deploy(
 
   const configuration = options.configuration
     ? options.configuration
-    : 'production';
+    : undefined;
 
   context.logger.info(
-    `📦 Building "${context.target.project}". Configuration: "${configuration}".`
+    `📦 Building "${context.target.project}". ${
+      configuration ? `Configuration "${configuration}"` : ''
+    }`
   );
 
-  const build = await context.scheduleTarget({
+  const target = {
     target: 'build',
-    project: context.target.project,
-    configuration
-  });
+    project: context.target.project
+  } as Target;
+
+  // Set the configuration if set on the options
+  if (configuration) {
+    target.configuration = configuration;
+  }
+
+  const build = await context.scheduleTarget(target);
   await build.result;
 
   await engine.run(

--- a/src/package-lock.json
+++ b/src/package-lock.json
@@ -1795,7 +1795,8 @@
         "ansi-regex": {
           "version": "2.1.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "aproba": {
           "version": "1.2.0",
@@ -1816,12 +1817,14 @@
         "balanced-match": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "brace-expansion": {
           "version": "1.1.11",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "balanced-match": "^1.0.0",
             "concat-map": "0.0.1"
@@ -1836,17 +1839,20 @@
         "code-point-at": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "concat-map": {
           "version": "0.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "console-control-strings": {
           "version": "1.1.0",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "core-util-is": {
           "version": "1.0.2",
@@ -1963,7 +1969,8 @@
         "inherits": {
           "version": "2.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "ini": {
           "version": "1.3.5",
@@ -1975,6 +1982,7 @@
           "version": "1.0.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "number-is-nan": "^1.0.0"
           }
@@ -1989,6 +1997,7 @@
           "version": "3.0.4",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "brace-expansion": "^1.1.7"
           }
@@ -1996,12 +2005,14 @@
         "minimist": {
           "version": "0.0.8",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "minipass": {
           "version": "2.3.5",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "safe-buffer": "^5.1.2",
             "yallist": "^3.0.0"
@@ -2020,6 +2031,7 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "minimist": "0.0.8"
           }
@@ -2100,7 +2112,8 @@
         "number-is-nan": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "object-assign": {
           "version": "4.1.1",
@@ -2112,6 +2125,7 @@
           "version": "1.4.0",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "wrappy": "1"
           }
@@ -2197,7 +2211,8 @@
         "safe-buffer": {
           "version": "5.1.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "safer-buffer": {
           "version": "2.1.2",
@@ -2233,6 +2248,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "code-point-at": "^1.0.0",
             "is-fullwidth-code-point": "^1.0.0",
@@ -2252,6 +2268,7 @@
           "version": "3.0.1",
           "bundled": true,
           "dev": true,
+          "optional": true,
           "requires": {
             "ansi-regex": "^2.0.0"
           }
@@ -2295,12 +2312,14 @@
         "wrappy": {
           "version": "1.0.2",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "yallist": {
           "version": "3.0.3",
           "bundled": true,
-          "dev": true
+          "dev": true,
+          "optional": true
         }
       }
     },


### PR DESCRIPTION
The seeder used force to have the configuration `production` when building the app. We do not need to do it on libraries.

close #2 