### PR TITLE
feat: add a packageVersion to options

### DIFF
--- a/src/deploy/schema.json
+++ b/src/deploy/schema.json
@@ -3,6 +3,10 @@
   "title": "schema",
   "description": "Deployment/Publishment of Angular CLI applications to NPM",
   "properties": {
+    "packageVersion": {
+      "type": "string",
+      "description": "the version string of the publishing package"
+    },
     "tag": {
       "type": "string",
       "description": "Registers the published package with the given tag, such that `npm install @` will install this version. By default, `npm publish` updates and `npm install` installs the `latest` tag. See `npm-dist-tag` for details about tags."

--- a/src/engine/utils/fs-async.ts
+++ b/src/engine/utils/fs-async.ts
@@ -1,0 +1,6 @@
+import util from 'util';
+import { readFile, writeFile } from 'fs';
+
+export const readFileAsync = util.promisify(readFile);
+
+export const writeFileAsync = util.promisify(writeFile);


### PR DESCRIPTION
add an option called `packageVersion` to enable update the package version before publishing to npm