### PR TITLE
feat: set deployer only on publishable libraries

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ This command has the following prerequisites:
 
 This quick start assumes that you already an existing Angular project with a publishable package created and you already are logged in in npm using `npm login`
 
-1. Add `ngx-deploy-npm` to your project. It will configure all your libraries present in the project
+1. Add `ngx-deploy-npm` to your project. It will configure all your publishable libraries present in the project
 
    ```sh
    ng add ngx-deploy-npm
@@ -188,6 +188,34 @@ The licence and the readme must be in the root of the library. They are being co
 
 This deployer do not bumps or creates a new version of the package, it just build the **package/library**, take the package.json as it and **publish** it.
 
+### Only publishable libraries are being configured
+
+A publishable library is one that can be built. Here we detect that if the library in the `angular.json` has the architect **build** with the builder `@angular-devkit/build-ng-packagr:build`.
+
+The `angular.json` look like
+
+```json
+{
+  "publishable-library": {
+    "projectType": "library",
+    "root": "libs/publishable-library",
+    "sourceRoot": "libs/publishable-library/src",
+    "prefix": "myworkspace",
+    "architect": {
+      "build": {
+        "builder": "@angular-devkit/build-ng-packagr:build",
+        "options": {
+          "tsConfig": "libs/publishable-library/tsconfig.lib.json",
+          "project": "libs/publishable-library/ng-package.json"
+        }
+      }
+    }
+  }
+}
+```
+
+This take special context in [NX](https://nx.dev) environment.
+
 **You must take care about the version by yourself. Maybe using a script that sets the version**
 
 ## 🏁 Next milestones <a name="next-milestones"></a>
@@ -199,8 +227,6 @@ We are looking forward to the following features:
   - Inspection
   - Delivery
 - Specify which library add the deployer on the `ng add`
-- Compatibility with [Nx](https://nx.dev)
-- Continuous Delivery Documentation
 - Add all the RFC proposals of [ngx-deploy-starter](https://github.com/angular-schule/ngx-deploy-starter)
 - ChangeLog Compatibility
 - Custom Readme and Licence Paths

--- a/src/ng-add.spec.ts
+++ b/src/ng-add.spec.ts
@@ -35,6 +35,7 @@ describe('ng-add', () => {
           prefix: 'myworkspace',
           architect: {
             build: {
+              builder: '@angular-devkit/build-ng-packagr:build',
               a: 'a',
               b: 'b'
             }
@@ -48,6 +49,7 @@ describe('ng-add', () => {
           prefix: 'myworkspace',
           architect: {
             build: {
+              builder: '@angular-devkit/build-ng-packagr:build',
               a: 'a',
               b: 'b'
             }
@@ -86,9 +88,11 @@ describe('ng-add', () => {
 
     expectedAngularJSON = JSON.parse(JSON.stringify(originalAngularJSON));
 
-    Object.keys(expectedAngularJSON.projects)
-      .map(projectKey => expectedAngularJSON.projects[projectKey])
-      .filter(project => project.projectType === 'library')
+    ['publishable', 'publishable2']
+      .map(
+        publishableProjectKey =>
+          expectedAngularJSON.projects[publishableProjectKey]
+      )
       .forEach(project => {
         if (project.architect) {
           project.architect.deploy = {
@@ -109,7 +113,7 @@ describe('ng-add', () => {
       tree.create('angular.json', JSON.stringify(originalAngularJSON));
     });
 
-    it('should set the deployer on all libraries', () => {
+    it('should set the deployer only on publishable libraries', () => {
       const result = ngAdd()(tree);
 
       const angularJsonModified = JSON.parse(
@@ -157,22 +161,6 @@ describe('ng-add', () => {
 
       expect(() => ngAdd()(treeWithoutLibs)).toThrowError(
         'There is no libraries to add this deployer'
-      );
-    });
-
-    it('should throw if there is a library without architect', () => {
-      const publishable2 = originalAngularJSON.projects.publishable2;
-      const root = publishable2.root;
-      // Delete the architect
-      delete publishable2.architect;
-      const treeWithoutArchitect = Tree.empty();
-      treeWithoutArchitect.create(
-        'angular.json',
-        JSON.stringify(originalAngularJSON)
-      );
-
-      expect(() => ngAdd()(treeWithoutArchitect)).toThrowError(
-        `The library ${root} doesn't have architect`
       );
     });
   });


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Right now, on `ng add ngx-deploy-npm` the deployer is set on all libraries even on those that are not publishable. 
On [nx](https://nx.dev) you can have publishable an non-publishable libraries (internal libraries) and adding the deployer to non-publishable libraries is pointless.

Issue Number: The is an issue on NX related to this feature ([nx 1800](https://github.com/nrwl/nx/issues/1800))

## What is the new behavior?

Only set the deployer on publishable libraries adding [nx](https://nx.dev) compatibility.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information