### PR TITLE
docs: update readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,9 +180,13 @@ And just run `ng deploy` 😄.
 
 ## 🧐 Essential considerations <a name="essential-considerations"></a>
 
-### Readme and Licence
+### README, LICENCE and CHANGELOG
 
-The licence and the readme must be in the root of the library. They are being copied at the moment of deployment
+Those files must be in the root of the library. They are being copied by the builder at the moment of deployment.
+
+If you have those files outside the project's root, you can create a symbolic link to solve that problem.
+
+> See [symbolic links on git](https://www.mokacoding.com/blog/symliks-in-git/) to know how to create them properly.
 
 ### Version bumping
 
@@ -228,8 +232,7 @@ We are looking forward to the following features:
   - Delivery
 - Specify which library add the deployer on the `ng add`
 - Add all the RFC proposals of [ngx-deploy-starter](https://github.com/angular-schule/ngx-deploy-starter)
-- ChangeLog Compatibility
-- Custom Readme and Licence Paths
+- Custom README, LICENCE and CHANGELOG paths
 
 Your feature that's not on the list yet?
 


### PR DESCRIPTION
## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The information about README, LICENCE and CHANGELOG files could be more helpful. Since version  __ng-packagr's__ 5.6.0 version the changelog file is [being copied to the pacakge destination](https://github.com/ng-packagr/ng-packagr/blob/master/CHANGELOG.md#features-1), so the goal of changelog compatibility is not longer needed.

Issue Number: N/A

## What is the new behavior?

- Changelog support goal is removed
- A more helpful information about how to handle the README, LICENCE and CHANGELOG files

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No


<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->


## Other information