### PR TITLE
chore: delete symbolic links to README and CHANGELOG files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,169 @@
-src/CHANGELOG.md
+# Changelog
+
+All notable changes to this project will be documented in this file. See [standard-version](https://github.com/conventional-changelog/standard-version) for commit guidelines.
+
+### [1.4.3](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.4.2...v1.4.3) (2021-02-27)
+
+
+### Bug Fixes
+
+* throws an error if app building fails ([072290a](https://github.com/bikecoders/ngx-deploy-npm/commit/072290a130e4b1dff5637515c8d2e29e38e4307a))
+
+### [1.4.2](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.4.1...v1.4.2) (2021-02-24)
+
+
+### Documentation
+
+* reduce cover image size on disk ([b44737f](https://github.com/bikecoders/ngx-deploy-npm/commit/b44737fbfed8a0200bff70b0fec090f9a80471ea))
+
+## [1.4.1](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.3.3...v1.4.1) (2021-02-18)
+
+
+### Features
+
+*  support Nx workspace ([15fc88a](https://github.com/bikecoders/ngx-deploy-npm/commit/15fc88a48cb6214960223157ab672bdb1c638701))
+
+### [1.3.3](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.3.2...v1.3.3) (2021-02-09)
+
+
+### Bug Fixes
+
+* add options to ngAdd schematic ([3570ac3](https://github.com/bikecoders/ngx-deploy-npm/commit/3570ac333d82473b3b7b55ebaf133f108dbc0ed7))
+
+
+### Documentation
+
+* improve documentation for contributors ([70dce30](https://github.com/bikecoders/ngx-deploy-npm/commit/70dce30a287f7f665897a4c71afc51c04ad95450))
+
+### [1.3.2](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.3.1...v1.3.2) (2020-12-09)
+
+
+### Documentation
+
+* improve builder description ([d0515d1](https://github.com/bikecoders/ngx-deploy-npm/commit/d0515d1))
+
+### [1.3.1](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.3.0...v1.3.1) (2020-12-08)
+
+
+### Bug Fixes
+
+* add support for AngularV11 ([a188ae2](https://github.com/bikecoders/ngx-deploy-npm/commit/a188ae2))
+
+## [1.3.0](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.2.4...v1.3.0) (2020-11-29)
+
+
+### Features
+
+* adds --no-build option to skip build ([743e4d4](https://github.com/bikecoders/ngx-deploy-npm/commit/743e4d4)), closes [angular-schule/ngx-deploy-starter#1](https://github.com/angular-schule/ngx-deploy-starter/issues/1)
+
+### [1.2.4](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.2.3...v1.2.4) (2020-11-14)
+
+
+### Documentation
+
+* fix discord URL ([2b75305](https://github.com/bikecoders/ngx-deploy-npm/commit/2b75305))
+
+### [1.2.3](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.2.2...v1.2.3) (2020-11-14)
+
+
+### Documentation
+
+* add discord server ([6f3b57c](https://github.com/bikecoders/ngx-deploy-npm/commit/6f3b57c))
+
+### [1.2.2](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.2.1...v1.2.2) (2020-04-29)
+
+
+### Documentation
+
+* fix a typo on the documention ([845daea](https://github.com/bikecoders/ngx-deploy-npm/commit/845daea))
+
+### [1.2.1](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.2.0...v1.2.1) (2020-04-28)
+
+
+### Bug Fixes
+
+* improve library checking ([aec3d05](https://github.com/bikecoders/ngx-deploy-npm/commit/aec3d05))
+
+
+### Documentation
+
+* fix the content table ([d3e33b1](https://github.com/bikecoders/ngx-deploy-npm/commit/d3e33b1))
+
+## [1.2.0](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.1.1...v1.2.0) (2020-01-25)
+
+### Documentation
+
+- create ngx-deploy-npm logo ([3e48d36](https://github.com/bikecoders/ngx-deploy-npm/commit/3e48d36))
+
+### Features
+
+- create `package-version` option to be able to set the package version of your library ([eb23865](https://github.com/bikecoders/ngx-deploy-npm/commit/eb23865))
+
+### [1.1.1](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.1.0...v1.1.1) (2019-11-07)
+
+### Bug Fixes
+
+- save package in devDependencies ([97d1ee1](https://github.com/bikecoders/ngx-deploy-npm/commit/97d1ee1))
+
+## [1.1.0](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.0.5...v1.1.0) (2019-10-21)
+
+### Documentation
+
+- set changelog on project root ([58dcbc9](https://github.com/bikecoders/ngx-deploy-npm/commit/58dcbc9))
+- update readme ([414ae4a](https://github.com/bikecoders/ngx-deploy-npm/commit/414ae4a))
+
+### Features
+
+- add nx compatibility ([9618c3b](https://github.com/bikecoders/ngx-deploy-npm/commit/9618c3b))
+
+### [1.0.5](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.0.4...v1.0.5) (2019-09-18)
+
+### Documentation
+
+- fix cover typo ([3eecf47](https://github.com/bikecoders/ngx-deploy-npm/commit/3eecf47))
+
+### [1.0.4](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.0.3...v1.0.4) (2019-09-18)
+
+### Documentation
+
+- tweak change log generation ([ced3480](https://github.com/bikecoders/ngx-deploy-npm/commit/ced3480))
+
+### Features
+
+- add standard-version ([bc76130](https://github.com/bikecoders/ngx-deploy-npm/commit/bc76130))
+
+### [1.0.3](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.0.2...v1.0.3) (2019-09-12)
+
+### Documentation
+
+- create ci instructions ([0b1f5f5](https://github.com/bikecoders/ngx-deploy-npm/commit/0b1f5f5))
+
+### [1.0.2](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.0.1...v1.0.2) (2019-09-12)
+
+### Code Refactoring
+
+- remove complex logic ([31f9003](https://github.com/bikecoders/ngx-deploy-npm/commit/31f9003))
+
+### [1.0.1](https://github.com/bikecoders/ngx-deploy-npm/compare/v1.0.0...v1.0.1) (2019-09-12)
+
+### Bug Fixes
+
+- do not force to build on production ([95471f2](https://github.com/bikecoders/ngx-deploy-npm/commit/95471f2))
+
+### [1.0.0](https://github.com/bikecoders/ngx-deploy-npm/compare/v0.0.1...v1.0.0) (2019-09-12)
+
+First version of `ngx-deploy-npm` 🥳
+
+### Features
+
+- add logic to publish to npm ([66adc24](https://github.com/bikecoders/ngx-deploy-npm/commit/66adc24))
+
+### Code Refactoring
+
+- get the variables needed for the builder ([6283731](https://github.com/bikecoders/ngx-deploy-npm/commit/6283731))
+- `ng add` modify only the libraries ([da28b27](https://github.com/bikecoders/ngx-deploy-npm/commit/da28b27))
+
+### Documentation
+
+- update readme and license ([97344c4](https://github.com/bikecoders/ngx-deploy-npm/commit/97344c4))
+- write the documentation's deployer ([fb2a9e3](https://github.com/bikecoders/ngx-deploy-npm/commit/fb2a9e3))

--- a/src/README.md
+++ b/src/README.md
@@ -1,1 +1,0 @@
-../README.md

--- a/src/package.json
+++ b/src/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "prebuild": "rimraf dist && json2ts deploy/schema.json > deploy/schema.d.ts",
     "build": "tsc -p tsconfig.build.json",
-    "postbuild": "copyfiles README.md LICENSE builders.json collection.json ng-add-schema.json package.json ngx-deploy-npm deploy/schema.json dist",
+    "postbuild": "copyfiles LICENSE builders.json collection.json ng-add-schema.json package.json ngx-deploy-npm deploy/schema.json dist && copyfiles --flat ../README.md dist",
     "predeploy": "npm run build",
     "deploy": "cd dist && npm publish --access public && cd ..",
     "link": "npm run build && cd dist && npm link && cd ..",
@@ -14,7 +14,7 @@
     "test": "jest",
     "test:cov": "jest --coverage",
     "test:debug": "node --inspect-brk=0.0.0.0 node_modules/.bin/jest --runInBand",
-    "release": "standard-version"
+    "release": "standard-version --infile ../CHANGELOG.md"
   },
   "schematics": "./collection.json",
   "builders": "./builders.json",
@@ -57,7 +57,7 @@
     "jest": "^24.8.0",
     "json-schema-to-typescript": "^7.0.0",
     "rimraf": "^2.6.3",
-    "standard-version": "^8.0.1",
+    "standard-version": "^9.1.1",
     "ts-jest": "^24.0.2",
     "typescript": "^3.5.3"
   },


### PR DESCRIPTION
## PR Checklist
Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)

## PR Type
What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Chore
- [ ] Refactoring (no functional changes, no api changes)
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

The symbolic links are kind of difficult to understand

Also, if we have the changelog on a different path, the renovate bots here on GitHub are not able to get the changelog and put it on the PR to upgrade the version, making it difficult for the maintainers, get the latest changes on that scenario is not straight forward.

Issue Number: N/A

## What is the new behavior?

Removed all the symbolic links and use the original files.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
