### PR TITLE
fix: add support for Nx workspace definition v2

### DIFF
--- a/src/interfaces.ts
+++ b/src/interfaces.ts
@@ -8,6 +8,14 @@ export interface WorkspaceProject {
       configurations?: Record<string, Record<string, any>>;
     }
   >;
+  targets?: Record<
+    string,
+    {
+      executor: string;
+      options?: Record<string, any>;
+      configurations?: Record<string, Record<string, any>>;
+    }
+  >;
 }
 
 export interface Workspace {

--- a/src/ng-add.ts
+++ b/src/ng-add.ts
@@ -74,8 +74,12 @@ function getLibraries({ projects }: Workspace): WorkspaceProject[] {
   return (
     Object.keys(projects)
       .map(projectKey => projects[projectKey])
-      // Check if the library is a publishable library (nx compatibility)
-      .filter(proj => proj.projectType === 'library' && proj.architect?.build)
+      // Check if the library is a buildable library (nx compatibility)
+      .filter(
+        proj =>
+          proj.projectType === 'library' &&
+          (proj?.architect?.build ?? proj?.targets?.build)
+      )
   );
 }
 


### PR DESCRIPTION
Hi @dianjuar, I'm back! 

I want to use ngx-deploy-npm in my Nx workspace in combination with @jscutlery/semver, unfortunately, it doesn't support the workspace definition version 2 so here is a quick fix. 

I saw you in the Nx conf and you seem interested in turning this library into an Nx plugin using the Devkit, I would really encourage you to do so. It would simplify the code and help with the support for both Nx + Angular CLI. If you need any help reach me out on Twitter or GitHub.

Cheers.