### PR TITLE
fix: set the right executor name

### DIFF
--- a/e2e/ngx-deploy-npm-e2e/tests/install.test-factory.ts
+++ b/e2e/ngx-deploy-npm-e2e/tests/install.test-factory.ts
@@ -34,7 +34,7 @@ export const installTest = () => {
 
   it('should modify the workspace for publishable libs', () => {
     const expectedTarget: TargetConfiguration = {
-      executor: '@bikecoders/ngx-deploy-npm:deploy',
+      executor: 'ngx-deploy-npm:deploy',
       options: {
         access: npmAccess.public,
       } as DeployExecutorOptions,

--- a/e2e/ngx-deploy-npm-e2e/tests/utils/utils-ngx-deploy-npm.ts
+++ b/e2e/ngx-deploy-npm-e2e/tests/utils/utils-ngx-deploy-npm.ts
@@ -3,17 +3,14 @@ import { ensureNxProject, runNxCommandAsync } from '@nrwl/nx-plugin/testing';
 export function initNgxDeployNPMProject() {
   // Init project
   beforeEach(async () => {
-    ensureNxProject(
-      '@bikecoders/ngx-deploy-npm',
-      'dist/packages/ngx-deploy-npm'
-    );
+    ensureNxProject('ngx-deploy-npm', 'dist/packages/ngx-deploy-npm');
 
-    await runNxCommandAsync('generate @bikecoders/ngx-deploy-npm:init');
+    await runNxCommandAsync('generate ngx-deploy-npm:init');
   }, 120000);
 }
 
 export function installNgxDeployNPMProject() {
   beforeEach(async () => {
-    await runNxCommandAsync('generate @bikecoders/ngx-deploy-npm:install');
+    await runNxCommandAsync('generate ngx-deploy-npm:install');
   }, 5000);
 }

--- a/packages/ngx-deploy-npm/src/generators/install/generator.spec.ts
+++ b/packages/ngx-deploy-npm/src/generators/install/generator.spec.ts
@@ -38,14 +38,14 @@ describe('install/ng-add generator', () => {
       workspaceConfig = new Map();
 
       expectedSimpleTarget = {
-        executor: '@bikecoders/ngx-deploy-npm:deploy',
+        executor: 'ngx-deploy-npm:deploy',
         options: {
           access: npmAccess.public,
         } as DeployExecutorOptions,
       };
 
       expectedTargetWithProductionMode = {
-        executor: '@bikecoders/ngx-deploy-npm:deploy',
+        executor: 'ngx-deploy-npm:deploy',
         options: {
           buildTarget: 'production',
           access: npmAccess.public,

--- a/packages/ngx-deploy-npm/src/generators/install/generator.ts
+++ b/packages/ngx-deploy-npm/src/generators/install/generator.ts
@@ -30,7 +30,7 @@ export default async function install(
       };
 
       libConfig.targets.deploy = {
-        executor: '@bikecoders/ngx-deploy-npm:deploy',
+        executor: 'ngx-deploy-npm:deploy',
         options: executorOptions,
       };
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related change
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: N/A

The executor name was wrong causing errors when trying to run the builder `deploy`

## What is the new behavior?

When the workspace.json is modified the right executor is being used.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
