### PR TITLE
build: remove NPM ngx-deploy-npm package and use build version

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,6 @@
     "eslint": "7.32.0",
     "eslint-config-prettier": "8.1.0",
     "jest": "27.2.3",
-    "ngx-deploy-npm": "^3.0.1",
     "prettier": "^2.3.1",
     "ts-jest": "27.0.5",
     "tslib": "^2.0.0",

--- a/workspace.json
+++ b/workspace.json
@@ -57,7 +57,7 @@
           }
         },
         "deploy": {
-          "executor": "ngx-deploy-npm:deploy",
+          "executor": "./dist/packages/ngx-deploy-npm:deploy",
           "options": {
             "access": "public"
           }

--- a/yarn.lock
+++ b/yarn.lock
@@ -705,18 +705,6 @@
     yargs "15.4.1"
     yargs-parser "20.0.0"
 
-"@nrwl/devkit@13.0.1":
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-13.0.1.tgz#fb91bf6e5d770ed477288a315fbf095130a4e5a2"
-  integrity sha512-fDLo8cu0Kn/iHt4i8aRArFV5Lsw/nYaIAzf3MILWgdh7113ksfgmaJbm7iVpoR6dHSpveqTFGaCrzm/CIVD7Zw==
-  dependencies:
-    "@nrwl/tao" "13.0.1"
-    ejs "^3.1.5"
-    ignore "^5.0.4"
-    rxjs "^6.5.4"
-    semver "7.3.4"
-    tslib "^2.0.0"
-
 "@nrwl/devkit@13.0.2":
   version "13.0.2"
   resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-13.0.2.tgz#7a22bb777894c8688545a36a113fa50e185fc80d"
@@ -834,23 +822,6 @@
     fs-extra "^9.1.0"
     jsonc-parser "3.0.0"
     nx "12.10.0"
-    rxjs "^6.5.4"
-    rxjs-for-await "0.0.2"
-    semver "7.3.4"
-    tmp "~0.2.1"
-    tslib "^2.0.0"
-    yargs-parser "20.0.0"
-
-"@nrwl/tao@13.0.1":
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/@nrwl/tao/-/tao-13.0.1.tgz#e8d6efc134635671c9780fc67b21e473ad346ffe"
-  integrity sha512-3dEgMst1MhM+pfztq58CWODXtRW6KUfMnZcqUCYK8wPkwN3H3Ym7Zo7uIvi3r+DlL9rf+6IOm2ikaGBACsGeCg==
-  dependencies:
-    chalk "4.1.0"
-    enquirer "~2.3.6"
-    fs-extra "^9.1.0"
-    jsonc-parser "3.0.0"
-    nx "13.0.1"
     rxjs "^6.5.4"
     rxjs-for-await "0.0.2"
     semver "7.3.4"
@@ -4504,13 +4475,6 @@ neo-async@^2.6.0, neo-async@^2.6.2:
   resolved "https://registry.yarnpkg.com/neo-async/-/neo-async-2.6.2.tgz#b4aafb93e3aeb2d8174ca53cf163ab7d7308305f"
   integrity sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==
 
-ngx-deploy-npm@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/ngx-deploy-npm/-/ngx-deploy-npm-3.0.1.tgz#5b22cb06b71984c11b507c7ec0bb9636af9399be"
-  integrity sha512-uOolEWvF/hHj3f2d+6SdyHijJNm/g6SFYK9KN/zaQeXYJo8yEqT/rM55RbYrSdl1HXBr1LpS4GwYsBFhUmwDAA==
-  dependencies:
-    "@nrwl/devkit" "13.0.1"
-
 nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
@@ -4602,13 +4566,6 @@ nx@12.10.0:
   version "12.10.0"
   resolved "https://registry.yarnpkg.com/nx/-/nx-12.10.0.tgz#a4e8fba7254529de69fe54e5b4b007e8a432a3fb"
   integrity sha512-LpCfZCWsVEtmD2SI1j2KRaw1uIyn4DJ3eRzsjnDYitbq38aORpkvYO+L0zVMZRNDSYSRGTsuj0nHCS3OOxK/Cg==
-  dependencies:
-    "@nrwl/cli" "*"
-
-nx@13.0.1:
-  version "13.0.1"
-  resolved "https://registry.yarnpkg.com/nx/-/nx-13.0.1.tgz#dc86255a7d4bc090789727277663e9927238048a"
-  integrity sha512-SVke3+POQJdNePyalqQlxV59eR1HNlQZ/5+g4W2U8nU97siSY+EITGAuGBAcSaNKwUluKSFQscro1NRhQ0keXg==
   dependencies:
     "@nrwl/cli" "*"
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" -->

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related change
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: N/A

@edbzn made a good point about stopping using the self NPM reference and pointing to the dist folder on the executor. https://github.com/bikecoders/ngx-deploy-npm/pull/84#pullrequestreview-790136509

## What is the new behavior?

The executor is using now quick of a nightly version of ngx-deploy-npm

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
