### PR TITLE
fix: allow paths with spaces

### DIFF
--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
@@ -48,7 +48,7 @@ describe('engine', () => {
     await engine.run(dir, options);
 
     expect(exec.execAsync).toHaveBeenCalledWith(
-      `npm publish ${dir} ${optionsOnCMD}`
+      `npm publish "${dir}" ${optionsOnCMD}`
     );
   });
 
@@ -76,7 +76,7 @@ describe('engine', () => {
       await engine.run(dir, options);
 
       expect(exec.execAsync).toHaveBeenCalledWith(
-        `npm publish ${dir} ${optionsOnCMD}`
+        `npm publish "${dir}" ${optionsOnCMD}`
       );
     });
 
@@ -91,7 +91,7 @@ describe('engine', () => {
       await engine.run(dir, options);
 
       expect(exec.execAsync).toHaveBeenCalledWith(
-        `npm publish ${dir} ${optionsOnCMD}`
+        `npm publish "${dir}" ${optionsOnCMD}`
       );
     });
 
@@ -105,7 +105,7 @@ describe('engine', () => {
       await engine.run(dir, options);
 
       expect(exec.execAsync).toHaveBeenCalledWith(
-        `npm publish ${dir} ${optionsOnCMD}`
+        `npm publish "${dir}" ${optionsOnCMD}`
       );
     });
   });

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
@@ -26,7 +26,7 @@ export async function run(dir: string, options: DeployExecutorOptions) {
     }
 
     const npmOptions = extractOnlyNPMOptions(options);
-    const commandToPublish = `npm publish ${dir} ${getOptionsString(
+    const commandToPublish = `npm publish "${dir}" ${getOptionsString(
       npmOptions
     )}`;
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" -->

- [x] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related change
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Target-paths with spaces result in an error, because the npm command recieves the path as two inputs

Issue Number: N/A

## What is the new behavior?

Target-paths can have spaces now

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
