### PR TITLE
build(fix): update semver to trigger postTargets feature

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "tslib": "^2.0.0"
   },
   "devDependencies": {
-    "@jscutlery/semver": "^2.10.0",
+    "@jscutlery/semver": "^2.11.4",
     "@nrwl/cli": "13.0.2",
     "@nrwl/devkit": "13.0.2",
     "@nrwl/eslint-plugin-nx": "13.0.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -652,14 +652,15 @@
     "@types/yargs" "^16.0.0"
     chalk "^4.0.0"
 
-"@jscutlery/semver@^2.10.0":
-  version "2.10.0"
-  resolved "https://registry.yarnpkg.com/@jscutlery/semver/-/semver-2.10.0.tgz#2f70bf6ba3b539be104fa72c73935e4cfea8b88d"
-  integrity sha512-fRxBcZhPgRZItZ0v/H4jThfa7WFN5+KoD+fNgWl6q+GSwfF5+TQqz3qXnTlJwbBKIVV4pMRmUGtWnfTwXbnqSg==
+"@jscutlery/semver@^2.11.4":
+  version "2.11.4"
+  resolved "https://registry.yarnpkg.com/@jscutlery/semver/-/semver-2.11.4.tgz#89b35b16a42d4d54e65dd6dabe6fa16cc539f9b3"
+  integrity sha512-Zc+B+TjndFOF0PXyJXWVKCc2RWgPRiMPukYntCMPv0ARBPgxQXa+NBwV/LJFwgPE/Q7Yy9LLNJ/1hX1pkBtF7g==
   dependencies:
-    "@nrwl/devkit" "^12.6.4"
-    inquirer "^8.1.1"
-    standard-version "^9.3.0"
+    "@nrwl/devkit" "^13.0.2"
+    inquirer "^8.2.0"
+    rxjs "^7.4.0"
+    standard-version "^9.3.2"
 
 "@nodelib/fs.scandir@2.1.5":
   version "2.1.5"
@@ -717,12 +718,12 @@
     semver "7.3.4"
     tslib "^2.0.0"
 
-"@nrwl/devkit@^12.6.4":
-  version "12.10.0"
-  resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-12.10.0.tgz#cf4a1dfb1036212185548d68296ac26e498a41c4"
-  integrity sha512-we0K5Hn48BXh77SV5GVSPfRJeIHNCVFSn+feLbnKz3G60Tk3wFEEFhDABA8cCfTKDxMESSjZoWBy4ZcVg0EX0g==
+"@nrwl/devkit@^13.0.2":
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/@nrwl/devkit/-/devkit-13.1.2.tgz#d92dcb9459533d96e2d20bfcc3d4c376a8c07f86"
+  integrity sha512-c6fzqUi8SqUZNMvT3OnOxbT2glDhEVgsnqMWWguwkjq/1TEehlSWrdMSH8CH50liIkdHiJ6hOzYX8wC+2tof7Q==
   dependencies:
-    "@nrwl/tao" "12.10.0"
+    "@nrwl/tao" "13.1.2"
     ejs "^3.1.5"
     ignore "^5.0.4"
     rxjs "^6.5.4"
@@ -839,6 +840,23 @@
     fs-extra "^9.1.0"
     jsonc-parser "3.0.0"
     nx "13.0.2"
+    rxjs "^6.5.4"
+    rxjs-for-await "0.0.2"
+    semver "7.3.4"
+    tmp "~0.2.1"
+    tslib "^2.0.0"
+    yargs-parser "20.0.0"
+
+"@nrwl/tao@13.1.2":
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/@nrwl/tao/-/tao-13.1.2.tgz#80f381b5f6d17d7e4bf4f52bb2e572a5da9eaff2"
+  integrity sha512-OF/zWpj7pdlBHS1Mr6uk3mtz0QUWb4W3KqKxO3wjj2GtRDwSGb8XFC+VbsRTxh/w+hoEOut10tvQiqAuJtuLGA==
+  dependencies:
+    chalk "4.1.0"
+    enquirer "~2.3.6"
+    fs-extra "^9.1.0"
+    jsonc-parser "3.0.0"
+    nx "13.1.2"
     rxjs "^6.5.4"
     rxjs-for-await "0.0.2"
     semver "7.3.4"
@@ -3024,7 +3042,7 @@ ini@^1.3.2:
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.8.tgz#a29da425b48806f34767a4efce397269af28432c"
   integrity sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==
 
-inquirer@^8.1.1:
+inquirer@^8.2.0:
   version "8.2.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-8.2.0.tgz#f44f008dd344bbfc4b30031f45d984e034a3ac3a"
   integrity sha512-0crLweprevJ02tTuA6ThpoAERAGyVILC4sS74uib58Xf/zSr1/ZWtmm7D5CI+bSQEaA04f0K7idaHpQbSWgiVQ==
@@ -4576,6 +4594,13 @@ nx@13.0.2:
   dependencies:
     "@nrwl/cli" "*"
 
+nx@13.1.2:
+  version "13.1.2"
+  resolved "https://registry.yarnpkg.com/nx/-/nx-13.1.2.tgz#961e789432d3229748ff0133f9d537ea2e690244"
+  integrity sha512-zLJtPr/4OD4C/OgvSaqRtIhj9WvZzUJPBrgRxW6ho60TGfmSvzH5cB3MUcZq+FClL0DXzv9mCFTw5XqqesyuWA==
+  dependencies:
+    "@nrwl/cli" "*"
+
 object-inspect@^1.11.0, object-inspect@^1.9.0:
   version "1.11.0"
   resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.11.0.tgz#9dceb146cedd4148a0d9e51ab88d34cf509922b1"
@@ -5089,7 +5114,7 @@ rxjs@^6.5.4:
   dependencies:
     tslib "^1.9.0"
 
-rxjs@^7.2.0:
+rxjs@^7.2.0, rxjs@^7.4.0:
   version "7.4.0"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-7.4.0.tgz#a12a44d7eebf016f5ff2441b87f28c9a51cebc68"
   integrity sha512-7SQDi7xeTMCJpqViXh8gL/lebcwlp3d831F05+9B44A4B0WfsEwUQHR64gsH1kvJ+Ep/J9K2+n1hVl1CsGN23w==
@@ -5329,7 +5354,7 @@ stack-utils@^2.0.3:
   dependencies:
     escape-string-regexp "^2.0.0"
 
-standard-version@^9.3.0:
+standard-version@^9.3.2:
   version "9.3.2"
   resolved "https://registry.yarnpkg.com/standard-version/-/standard-version-9.3.2.tgz#28db8c1be66fd2d736f28f7c5de7619e64cd6dab"
   integrity sha512-u1rfKP4o4ew7Yjbfycv80aNMN2feTiqseAhUhrrx2XtdQGmu7gucpziXe68Z4YfHVqlxVEzo4aUA0Iu3VQOTgQ==


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] The commit message follows our guidelines: https://www.conventionalcommits.org/en/v1.0.0/
- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x" -->

- [ ] Bugfix
- [ ] Feature
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related change
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: N/A

The Semver's `postTarget` feature did not run the executor with the suitable options; for some reason, all options with default values had as value `true`. For our scenario, `dryRun` and `noBuild` were true, leading to unwanted behavior.

## What is the new behavior?

Updating Semver to the last version solve this problem

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
