### PR TITLE
ci: avoid running publishment deployment on autogenerated commits

### DIFF
--- a/.github/workflows/publishment.yml
+++ b/.github/workflows/publishment.yml
@@ -3,11 +3,10 @@ on:
   push:
     branches:
       - master
-    tags-ignore:
-      - 'v*'
 
 jobs:
   test:
+    if: ${{ !contains(github.event.head_commit.message, 'chore(release)') }}
     uses: bikecoders/ngx-deploy-npm/.github/workflows/basic-test.yml@master #@master
 
   analysis:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: N/A

The publishment workflow is executed on undesired commits

## What is the new behavior?

Avoid running publishment workflow on autogenerated commits when generating a new version

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
