### PR TITLE
ci: use reusable workflow using local path instead of repo reference

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,10 +8,10 @@ env:
 
 jobs:
   pr-test:
-    uses: bikecoders/ngx-deploy-npm/.github/workflows/basic-test.yml@master #@master
+    uses: ./.github/workflows/basic-test.yml
 
   pr-e2e-test:
-    uses: bikecoders/ngx-deploy-npm/.github/workflows/e2e-test.yml@master #@master
+    uses: ./.github/workflows/e2e-test.yml
 
   check-commit-lint:
     name: Check commit message follows guidelines

--- a/.github/workflows/publishment.yml
+++ b/.github/workflows/publishment.yml
@@ -7,11 +7,11 @@ on:
 jobs:
   test:
     if: ${{ !contains(github.event.head_commit.message, 'chore(release)') }}
-    uses: bikecoders/ngx-deploy-npm/.github/workflows/basic-test.yml@master #@master
+    uses: ./.github/workflows/basic-test.yml
 
   e2e-test:
     if: ${{ !contains(github.event.head_commit.message, 'chore(release)') }}
-    uses: bikecoders/ngx-deploy-npm/.github/workflows/e2e-test.yml@master #@master
+    uses: ./.github/workflows/e2e-test.yml
 
   analysis:
     name: SonarCloud Main Analysis


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: N/A

We were using a reusable workflow using a repo path. That's inconvenient at the moment of modifying it, you need to toggle the master branch between the branch that you are working and that is error-prone.

## What is the new behavior?

Seems that now is possible to reference a reusable workflow using a relative path

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

https://docs.github.com/en/actions/using-workflows/reusing-workflows#calling-a-reusable-workflow