### PR TITLE
ci: separate e2e from basic-test

### DIFF
--- a/.github/workflows/basic-test.yml
+++ b/.github/workflows/basic-test.yml
@@ -49,17 +49,3 @@ jobs:
         with:
           name: ngx-deploy-npm-coverage-report-${{ github.sha }}
           path: coverage/packages/ngx-deploy-npm/lcov.info
-
-  e2e-test:
-    runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node-version: [12, 14, 16]
-    steps:
-      - uses: actions/checkout@v2
-        with:
-          fetch-depth: 0
-      - uses: ./.github/actions/setup
-        with:
-          node-version: ${{ matrix.node-version }}
-      - run: npx nx e2e ngx-deploy-npm-e2e

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ jobs:
   pr-test:
     uses: bikecoders/ngx-deploy-npm/.github/workflows/basic-test.yml@master #@master
 
+  pr-e2e-test:
+    uses: bikecoders/ngx-deploy-npm/.github/workflows/e2e-test.yml@master #@master
+
   check-commit-lint:
     name: Check commit message follows guidelines
     runs-on: ubuntu-latest

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -1,0 +1,18 @@
+name: E2E Test
+
+on: workflow_call
+
+jobs:
+  e2e-test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [12, 14, 16]
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - uses: ./.github/actions/setup
+        with:
+          node-version: ${{ matrix.node-version }}
+      - run: npx nx e2e ngx-deploy-npm-e2e

--- a/.github/workflows/publishment.yml
+++ b/.github/workflows/publishment.yml
@@ -9,6 +9,10 @@ jobs:
     if: ${{ !contains(github.event.head_commit.message, 'chore(release)') }}
     uses: bikecoders/ngx-deploy-npm/.github/workflows/basic-test.yml@master #@master
 
+  e2e-test:
+    if: ${{ !contains(github.event.head_commit.message, 'chore(release)') }}
+    uses: bikecoders/ngx-deploy-npm/.github/workflows/e2e-test.yml@master #@master
+
   analysis:
     name: SonarCloud Main Analysis
     runs-on: ubuntu-latest
@@ -26,7 +30,7 @@ jobs:
 
   release-preliminar:
     runs-on: ubuntu-latest
-    needs: test
+    needs: [test, e2e-test]
     steps:
       - uses: actions/checkout@v2
       - uses: ./.github/actions/setup


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: N/A

Currently, the e2e tests are part of the basic test, and some operations depend on those basic tests to execute. E2E tests take almost 7minutes to complete, and they're slowing down the development process.

E2E we depend on build, lint (coming soon), and unit test to execute other operations but not for e2e test, and there is no way to indicate in a reusable workflow to specify that you need an inner job. https://github.com/github/feedback/discussions/11072

## What is the new behavior?

Separate the e2e tests from the primary tests gaining agility and making the CI faster.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Tested on https://github.com/bikecoders/ngx-deploy-npm/actions/runs/1803099858

![image](https://user-images.githubusercontent.com/7026066/152696687-1e877745-5153-4c52-aeaf-ffa1ecca9c8c.png)
