### PR TITLE
build: drop node12 and adopt node18

### DIFF
--- a/.github/workflows/basic-test.yml
+++ b/.github/workflows/basic-test.yml
@@ -43,7 +43,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16, 18]
     steps:
       - uses: actions/checkout@v3
         with:

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [12, 14, 16]
+        node-version: [14, 16, 18]
     steps:
       - uses: actions/checkout@v3
         with:


### PR DESCRIPTION
Drop support for node v12 and adopt node v18.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: #249

## What is the new behavior?

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

`ngx-deploy-npm` no longer supports node v12. Please update node v14, v16, or v18 to continue support. 

## Other information
