### PR TITLE
build: remove deprecated option on renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -19,6 +19,6 @@
     }
   ],
   "rangeStrategy": "update-lockfile",
-  "commitMessage": "{{{commitMessagePrefix}}} 📦 {{{commitMessageAction}}} {{{commitMessageTopic}}} {{{commitMessageExtra}}} {{{commitMessageSuffix}}}",
+  "commitMessageAction": "📦",
   "schedule": ["before 3am on the first day of the month"]
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you modify or link to a relevant issue. -->

Issue Number: N/A

The Dependency Dashboard (#110) is complaining about some warnings in the renovate configuration.

## What is the new behavior?

The renovate's log shows the following warning.
![image](https://user-images.githubusercontent.com/7026066/163095990-3c829956-89e4-4f9d-b1e1-ebb11bf58250.png)

[Cypress's](https://github.com/cypress-io/cypress/pull/16396) have faced this issue before


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
