### PR TITLE
build: add package emoji to lock maintenance renovate commit's message

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,7 +6,8 @@
   "lockFileMaintenance": {
     "enabled": true,
     "automerge": true,
-    "automergeType": "pr"
+    "automergeType": "pr",
+    "commitMessageAction": "📦"
   },
   "packageRules": [
     {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you modify or link to a relevant issue. -->

Issue Number: N/A

The lock file maintenance commit is not showing the package emoji.

## What is the new behavior?

Adds the package emoji to the commit message to have a homogeneous renovate's commit messages

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
