### PR TITLE
test: update ts-jest config deprecated on V29

### DIFF
--- a/e2e/ngx-deploy-npm-e2e/jest.config.js
+++ b/e2e/ngx-deploy-npm-e2e/jest.config.js
@@ -1,13 +1,13 @@
 module.exports = {
   displayName: 'ngx-deploy-npm-e2e',
   preset: '../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-    },
-  },
   transform: {
-    '^.+\\.[tj]s$': 'ts-jest',
+    '^.+\\.[tj]s$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
   },
   moduleFileExtensions: ['ts', 'js', 'html'],
   coverageDirectory: '../../coverage/e2e/ngx-deploy-npm-e2e',

--- a/packages/ngx-deploy-npm/jest.config.js
+++ b/packages/ngx-deploy-npm/jest.config.js
@@ -1,14 +1,14 @@
 module.exports = {
   displayName: 'ngx-deploy-npm',
   preset: '../../jest.preset.js',
-  globals: {
-    'ts-jest': {
-      tsconfig: '<rootDir>/tsconfig.spec.json',
-    },
-  },
   testEnvironment: 'node',
   transform: {
-    '^.+\\.[tj]sx?$': 'ts-jest',
+    '^.+\\.[tj]sx?$': [
+      'ts-jest',
+      {
+        tsconfig: '<rootDir>/tsconfig.spec.json',
+      },
+    ],
   },
   moduleFileExtensions: ['ts', 'tsx', 'js', 'jsx'],
   coverageDirectory: '../../coverage/packages/ngx-deploy-npm',


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: N/A

> Define ts-jest config under globals is now deprecated. Please define the config via transformer config instead.

See https://github.com/bikecoders/ngx-deploy-npm/pull/377 for `ts-jest` deprecation notes

When running the test, it lunches a warning:

```
ts-jest[ts-jest-transformer] (WARN) Define `ts-jest` config under `globals` is deprecated. Please do
transform: {
    <transform_regex>: ['ts-jest', { /* ts-jest config goes here in Jest */ }],
},
```
https://github.com/bikecoders/ngx-deploy-npm/actions/runs/3201478983/jobs/5229501587#step:5:12

## What is the new behavior?

Updates ts-jest configuration to v29

Warning gone:

https://github.com/bikecoders/ngx-deploy-npm/actions/runs/3202447548/jobs/5231438195

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
