### PR TITLE
fix: increment exec buffer size to allow package publishment with a large set of files

### DIFF
--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
@@ -48,7 +48,8 @@ describe('engine', () => {
     await engine.run(dir, options);
 
     expect(exec.execAsync).toHaveBeenCalledWith(
-      `npm publish "${dir}" ${optionsOnCMD}`
+      `npm publish "${dir}" ${optionsOnCMD}`,
+      expect.anything()
     );
   });
 
@@ -71,7 +72,8 @@ describe('engine', () => {
       await engine.run(dir, options);
 
       expect(exec.execAsync).toHaveBeenCalledWith(
-        `npm publish "${dir}" ${optionsOnCMD}`
+        `npm publish "${dir}" ${optionsOnCMD}`,
+        expect.anything()
       );
     });
 
@@ -86,7 +88,8 @@ describe('engine', () => {
       await engine.run(dir, options);
 
       expect(exec.execAsync).toHaveBeenCalledWith(
-        `npm publish "${dir}" ${optionsOnCMD}`
+        `npm publish "${dir}" ${optionsOnCMD}`,
+        expect.anything()
       );
     });
 
@@ -100,7 +103,8 @@ describe('engine', () => {
       await engine.run(dir, options);
 
       expect(exec.execAsync).toHaveBeenCalledWith(
-        `npm publish "${dir}" ${optionsOnCMD}`
+        `npm publish "${dir}" ${optionsOnCMD}`,
+        expect.anything()
       );
     });
   });

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
@@ -30,7 +30,10 @@ export async function run(dir: string, options: DeployExecutorOptions) {
       npmOptions
     )}`;
 
-    const { stdout, stderr } = await execAsync(commandToPublish);
+    const maxBuffer = 100 * 1024 * 1024; // 100 times bigger than the default
+    const { stdout, stderr } = await execAsync(commandToPublish, {
+      maxBuffer, // Hot Fix for #401. A definitive solutions seems to replace exec in favor of spawn
+    });
 
     logger.info(stdout);
     logger.info(stderr);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: Hotfix for #401

## What is the new behavior?

Increment temporary the exec buffer size to prevent errors when executing npm publish for packages with many files.

This is a temporary solution as we migrate from `child_process.exec` [`child_process.spawn`](https://nodejs.org/api/child_process.html#child_processspawncommand-args-options) instead.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
