### PR TITLE
fix: widen peer dependencies on nx

### DIFF
--- a/packages/ngx-deploy-npm/package.json
+++ b/packages/ngx-deploy-npm/package.json
@@ -10,8 +10,10 @@
   "engines": {
     "node": ">=14.0.0"
   },
-  "dependencies": {
-    "@nrwl/devkit": "15.6.2"
+  "peerDependencies": {
+    "@nrwl/devkit": "^15.0.0",
+    "@nrwl/workspace": "^15.0.0",
+    "nx": "^15.0.0"
   },
   "ng-add": {
     "save": "devDependencies"


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
Applications can't install latest versions of `nx` because the dependency is pinned.

Closes #470 

## What is the new behavior?

The dependency version is widened, so any version within last major version of nx `^15.0.0` would be supported.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

Potentially this is a breaking change if: 1) Consumer apps doesn't have `nx` installed (Angular workspace) and 2) Using legacy peer dependencies (those won't be installed)

The result would be that installation would fail. Installing peer dependencies is the default since npm 7, so it is been a while already, and as mentioned in #470 it is the standard. If we want to make this change 100% non-breaking, we could keep them as just `dependencies`, and schedule this change for the next major version. Open for comments.

Regarding opening for v14, I'd propose to treat that in a separate PR, alongside the e2e tests to ensure compatibility.

## Other information
