### PR TITLE
feat: add "registry" option for the deploy executor

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,14 @@ Tells the registry whether to publish the package as public or restricted. It on
 
 If you have two-factor authentication enabled in auth-and-writes mode, you can provide a code from your authenticator.
 
+#### `--registry`
+
+- **optional**
+- Example:
+  - `nx deploy --registry http://localhost:4873`
+
+Configure npm to use any compatible registry you like, and even run your own registry.
+
 #### `--dry-run`
 
 - **optional**
@@ -302,7 +310,7 @@ configuration in the `workspace.json` file in the `options` attribute
 of your deploy project's executor.
 Just change the option to lower camel case.
 
-A list of all available options is also available [here](https://github.com/bikecoders/ngx-deploy-npm/blob/main/src/deploy/schema.json).
+A list of all available options is also available [here](https://github.com/bikecoders/ngx-deploy-npm/blob/main/packages/ngx-deploy-npm/src/executors/deploy/schema.json).
 
 Example:
 

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
@@ -28,6 +28,7 @@ describe('engine', () => {
       tag: 'next',
       otp: 'someValue',
       buildTarget: 'production',
+      registry: 'http://localhost:4873',
       dryRun: true,
     };
     const optionsArray = [
@@ -39,6 +40,8 @@ describe('engine', () => {
       'someValue',
       '--dry-run',
       'true',
+      '--registry',
+      'http://localhost:4873',
     ];
 
     await engine.run(dir, options);
@@ -73,32 +76,6 @@ describe('engine', () => {
       ]);
     });
 
-    it('should overwrite the default option dry-run', async () => {
-      const options: DeployExecutorOptions = {
-        otp: 'random-text',
-        dryRun: true,
-        tag: 'random-tag',
-      };
-      const optionsArray = [
-        '--access',
-        'public',
-        '--tag',
-        options.tag,
-        '--otp',
-        options.otp,
-        '--dry-run',
-        'true',
-      ];
-
-      await engine.run(dir, options);
-
-      expect(spawn.spawnAsync).toHaveBeenCalledWith('npm', [
-        'publish',
-        dir,
-        ...optionsArray,
-      ]);
-    });
-
     it('should overwrite the default option access', async () => {
       const options = {
         tag: 'random-tag',
@@ -108,7 +85,7 @@ describe('engine', () => {
         '--access',
         npmAccess.restricted,
         '--tag',
-        options.tag,
+        'random-tag',
       ];
 
       await engine.run(dir, options);

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
@@ -57,12 +57,14 @@ function extractOnlyNPMOptions({
   tag,
   otp,
   dryRun,
+  registry,
 }: DeployExecutorOptions): NpmPublishOptions {
   return {
     access,
     tag,
     otp,
     dryRun,
+    registry,
   };
 }
 

--- a/packages/ngx-deploy-npm/src/executors/deploy/schema.d.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/schema.d.ts
@@ -28,6 +28,10 @@ export interface DeployExecutorOptions {
    */
   otp?: string | number;
   /**
+   * Configure npm to use any compatible registry you like, and even run your own registry.
+   */
+  registry?: string;
+  /**
    * For testing: Run through without making any changes. Execute with --dry-run and nothing will happen.
    */
   dryRun?: boolean;

--- a/packages/ngx-deploy-npm/src/executors/deploy/schema.json
+++ b/packages/ngx-deploy-npm/src/executors/deploy/schema.json
@@ -38,6 +38,10 @@
       "type": ["string", "number"],
       "description": "If you have two-factor authentication enabled in auth-and-writes mode then you can provide a code from your authenticator with this. If you don't include this and you're running from a TTY then you'll be prompted."
     },
+    "registry": {
+      "type": "string",
+      "description": "Configure npm to use any compatible registry you like, and even run your own registry."
+    },
     "dryRun": {
       "type": "boolean",
       "description": "For testing: Run through without making any changes. Execute with --dry-run and nothing will happen.",

--- a/packages/ngx-deploy-npm/src/executors/deploy/utils/default-options.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/utils/default-options.ts
@@ -2,8 +2,5 @@ import { npmAccess } from '../../../core';
 import { NpmPublishOptions } from './interfaces';
 
 export const defaults: NpmPublishOptions = {
-  tag: undefined,
   access: npmAccess.public,
-  otp: undefined,
-  dryRun: false,
 };

--- a/packages/ngx-deploy-npm/src/executors/deploy/utils/interfaces.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/utils/interfaces.ts
@@ -2,7 +2,7 @@ import { DeployExecutorOptions } from '../schema';
 
 export type NpmPublishOptions = Pick<
   DeployExecutorOptions,
-  'access' | 'tag' | 'otp' | 'dryRun'
+  'access' | 'tag' | 'otp' | 'dryRun' | 'registry'
 >;
 
 export interface BuildTarget {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx (for bug fixes/features)

## What is the current behavior?
Right now there's no ability to deploy to other registries. This might be useful if we want to add another deployment configuration for testing purposes
<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?
Adding the new `--registry` options for the deploy executor. This will allow to deploy the package into other registries or tools like https://verdaccio.org/docs/what-is-verdaccio/
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
