### PR TITLE
chore: create nx target to create nx workspace sandbox

### DIFF
--- a/packages/ngx-deploy-npm/project.json
+++ b/packages/ngx-deploy-npm/project.json
@@ -70,6 +70,21 @@
         "postTargets": ["ngx-deploy-npm:deploy"],
         "versionTagPrefix": "v"
       }
+    },
+    "yalc-it": {
+      "executor": "nx:run-commands",
+      "options": {
+        "command": "cd dist/packages/ngx-deploy-npm && npx --yes yalc publish"
+      },
+      "dependsOn": ["build"]
+    },
+    "create-nx-workspace": {
+      "executor": "nx:run-commands",
+      "outputs": ["{workspaceRoot}/tmp/nx-workspace"],
+      "options": {
+        "command": "./tools/create-nx-workspace.sh"
+      },
+      "dependsOn": ["yalc-it"]
     }
   },
   "tags": []

--- a/tools/create-nx-workspace.sh
+++ b/tools/create-nx-workspace.sh
@@ -2,27 +2,32 @@
 
 set -e
 
+version="${1:-latest}"
+
 mkdir -p tmp
 cd tmp
 
 # Delete the previous workspace
 rm -Rif nx-workspace
 
-npx create-nx-workspace --version
+npx --yes create-nx-workspace@$version --version
 
-echo "Create Nx Workspace"
-npx create-nx-workspace --packageManager yarn --name nx-workspace --preset empty  --nxCloud false
+echo "----- Create Nx Workspace -----"
+npx create-nx-workspace@$version --name nx-workspace --preset empty --nxCloud false
 cd nx-workspace
 
-echo "Generate lib"
-yarn add -D @nrwl/node
+echo "NX_WORKSPACE_ROOT_PATH=$(pwd)" >.env
+
+echo "----- Generate lib -----"
+npm add -D @nrwl/node@$version
 npx nx generate @nrwl/node:lib --name nx-lib --publishable --importPath nx-lib
 
-echo "Link ngx-deploy-npm"
-yarn link ngx-deploy-npm
+echo "----- Link ngx-deploy-npm -----"
+npx yalc add ngx-deploy-npm
+npm i
 
-echo "Add ngx-deploy-npm to the workspace"
+echo "----- Add ngx-deploy-npm to the workspace -----"
 npx nx generate ngx-deploy-npm:install
 
-echo "Test the build"
+echo "----- Test the build -----"
 npx nx deploy nx-lib --dry-run


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)
- [x] Both workspaces were tested Angular and Nx (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: N/A

In the past, we had a script to create an nx workspace sandbox to have an actual test workspace. That script was hidden, and its execution was primitive. You had to do it by hand `./tools/create-nx-workspace.sh`

## What is the new behavior?

Create a target to create an nx workspace sandbox.

`npx nx create-nx-workspace`

Also, the script now receives a parameter indicating which version creates the nx worspace.

```bash
npx nx create-nx-workspace -- 14.8.6 # will create the nx workspace with nx V14.8.6
```

This could be a potential solution for #482 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
