### PR TITLE
fix: set the right peerDependency on ngx-deploy-npm's package.json

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -4,6 +4,13 @@
   "plugins": ["@nx"],
   "overrides": [
     {
+      "files": ["package.json"],
+      "parser": "jsonc-eslint-parser",
+      "rules": {
+        "@nx/dependency-checks": "error"
+      }
+    },
+    {
       "files": ["*.ts", "*.tsx", "*.js", "*.jsx"],
       "rules": {
         "@nx/enforce-module-boundaries": [

--- a/packages/ngx-deploy-npm/package.json
+++ b/packages/ngx-deploy-npm/package.json
@@ -11,7 +11,8 @@
     "node": ">=18.0.0"
   },
   "peerDependencies": {
-    "@nx/devkit": "^16.0.0"
+    "@nx/devkit": "^16.0.0",
+    "tslib": "^2.3.0"
   },
   "ng-add": {
     "save": "devDependencies"

--- a/packages/ngx-deploy-npm/project.json
+++ b/packages/ngx-deploy-npm/project.json
@@ -8,7 +8,10 @@
       "executor": "@nx/linter:eslint",
       "outputs": ["{options.outputFile}"],
       "options": {
-        "lintFilePatterns": ["packages/ngx-deploy-npm/**/*.ts"],
+        "lintFilePatterns": [
+          "packages/ngx-deploy-npm/**/*.ts",
+          "packages/ngx-deploy-npm/package.json"
+        ],
         "outputFile": "reports/ngx-deploy-npm/lint-report"
       }
     },
@@ -56,8 +59,7 @@
             "glob": "executors.json",
             "output": "."
           }
-        ],
-        "updateBuildableProjectDepsInPackageJson": true
+        ]
       }
     },
     "deploy": {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->
when installing ngx-deploy-npm 7.0.0 the following error occurs:

```
npm ERR! Found: tslib@2.6.1
npm ERR! node_modules/tslib
npm ERR!   dev tslib@"^2.3.0" from the root project
npm ERR!   tslib@"^2.3.0" from @nx/devkit@16.6.0
npm ERR!   node_modules/@nx/devkit
npm ERR!     peer @nx/devkit@"^16.0.0" from ngx-deploy-npm@7.0.0
npm ERR!     node_modules/ngx-deploy-npm
npm ERR!       dev ngx-deploy-npm@"7.0.0" from the root project
npm ERR!   3 more (nx, @swc-node/register, @swc/helpers)
npm ERR! 
npm ERR! Could not resolve dependency:
npm ERR! peer tslib@"1.14.1" from ngx-deploy-npm@7.0.0
npm ERR! node_modules/ngx-deploy-npm
npm ERR!   dev ngx-deploy-npm@"7.0.0" from the root project
```

The option `updateBuildableProjectDepsInPackageJson` is [deprecated](https://nx.dev/packages/angular/executors/package#buildableprojectdepsinpackagejsontype), and Nx doesn't automatically update your library's peerDependencies. You need to do it by hand by default.

We implement a semi-automated way of knowing when it's time to update the package's dependencies using an [ESLint Rule](https://nx.dev/packages/eslint-plugin/documents/dependency-checks#dependency-checks-rule).

Issue Number: 
close #535

## What is the new behavior?

Fixes the V7 npm installation error.

The lint process will indicate to us when it's time to update the package's dependencies. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
