### PR TITLE
feat(ngx-deploy-npm): add version check to prevent duplicate publishes

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@
     - [`--project`](#--project)
     - [`--access`](#--access-install)
   - [deploy](#deploy)
+    - [`--check-existing`](#--check-existing)
     - [`--package-version`](#--package-version)
     - [`--tag`](#--tag)
     - [`--access`](#--access)
@@ -174,6 +175,17 @@ Tells the registry whether to publish the package as public or restricted. It on
 
 Indicate the dist folder path.
 The path must relative to project's root.
+
+#### `--check-existing`
+
+- **optional**
+- Example:
+  - `nx deploy --check-existing=warning`
+  - `nx deploy --check-existing=error`
+
+Check if the package version already exists before publishing.
+If it exists and `--check-existing=warning`, it will skip the publishing and log a warning.
+If it exists and `--check-existing=error`, it will throw an error.
 
 #### `--package-version`
 

--- a/packages/ngx-deploy-npm-e2e/src/publish.spec.ts
+++ b/packages/ngx-deploy-npm-e2e/src/publish.spec.ts
@@ -33,4 +33,23 @@ describe('Publish', () => {
     },
     120000 * 2
   );
+
+  it('should NOT publish because it already exists', async () => {
+    const { processedLibs, tearDown, executeCommand } = await setup([
+      { name: uniq('minimal-lib'), generator: 'minimal' },
+    ]);
+    const [uniqLibName] = processedLibs;
+
+    executeCommand(
+      `npx nx deploy ${uniqLibName.name} --tag="e2e" --registry=http://localhost:4873 --packageVersion=0.0.0 --checkExisting="error"`
+    );
+
+    expect(() => {
+      executeCommand(
+        `npx nx deploy ${uniqLibName.name} --tag="e2e" --registry=http://localhost:4873 --packageVersion=0.0.0 --checkExisting="error"`
+      );
+    }).toThrow();
+
+    return tearDown();
+  }, 120000);
 });

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
@@ -4,6 +4,14 @@ import * as engine from './engine';
 import * as spawn from '../utils/spawn-async';
 import * as setPackage from '../utils/set-package-version';
 import { mockProjectDist, mockProjectRoot } from '../../../__mocks__/mocks';
+import * as fileUtils from '../../../utils';
+
+jest.mock('../../../utils', () => {
+  return {
+    __esModule: true, //    <----- this __esModule: true is important
+    ...jest.requireActual('../../../utils'),
+  };
+});
 
 describe('engine', () => {
   const defaultOption: Readonly<Omit<DeployExecutorOptions, 'distFolderPath'>> =
@@ -126,6 +134,149 @@ describe('engine', () => {
       await engine.run(absoluteDistFolderPath, options);
 
       expect(setPackage.setPackageVersion).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Package Version Check Feature', () => {
+    const defaultMockPackageJson = {
+      name: '@test/package',
+      version: '1.0.0',
+    };
+
+    const versionCheckSetup = ({
+      mockPackageJson = defaultMockPackageJson,
+      npmViewResult = () => Promise.resolve(),
+      npmPublishResult = () => Promise.resolve(),
+      ...originalSetupOptions
+    }: {
+      mockPackageJson?: { name: string; version: string };
+      npmViewResult?: () => Promise<void>;
+      npmPublishResult?: () => Promise<void>;
+    } & Parameters<typeof setup>[0] = {}) => {
+      jest
+        .spyOn(fileUtils, 'readFileAsync')
+        .mockImplementation(() =>
+          Promise.resolve(JSON.stringify(mockPackageJson))
+        );
+
+      // Ne pas utiliser le setup standard qui écrase notre mock
+      const setupResult = {
+        absoluteDistFolderPath: `${mockProjectRoot}/${mockProjectDist()}`,
+        options: {
+          ...defaultOption,
+          ...originalSetupOptions.options,
+          distFolderPath: mockProjectDist(),
+        },
+      };
+
+      // Mock spawnAsync directement
+      jest.spyOn(spawn, 'spawnAsync').mockImplementation((cmd, args) => {
+        return args?.[0] === 'view'
+          ? npmViewResult()
+          : args?.[0] === 'publish'
+          ? npmPublishResult()
+          : Promise.resolve();
+      });
+
+      return {
+        ...setupResult,
+        mockPackageJson,
+      };
+    };
+
+    it('should skip publishing when package exists and checkExisting is warning', async () => {
+      const { absoluteDistFolderPath, options, mockPackageJson } =
+        versionCheckSetup({
+          options: {
+            ...defaultOption,
+            checkExisting: 'warning',
+          },
+          npmViewResult: () => Promise.resolve(),
+          npmPublishResult: () => Promise.resolve(),
+        });
+
+      await engine.run(absoluteDistFolderPath, {
+        ...options,
+        checkExisting: 'warning',
+      });
+
+      // Verify package check was performed
+      expect(spawn.spawnAsync).toHaveBeenCalledWith('npm', [
+        'view',
+        `${mockPackageJson.name}@${mockPackageJson.version}`,
+        'version',
+      ]);
+
+      // Verify publish was not called
+      expect(spawn.spawnAsync).not.toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['publish'])
+      );
+    });
+
+    it('should throw error when package exists and checkExisting is "error"', async () => {
+      const { absoluteDistFolderPath, options, mockPackageJson } =
+        versionCheckSetup({
+          options: {
+            ...defaultOption,
+            checkExisting: 'error',
+          },
+          npmViewResult: () => Promise.resolve(),
+          npmPublishResult: () => Promise.resolve(),
+        });
+
+      // Should throw specific error when package exists
+      await expect(() =>
+        engine.run(absoluteDistFolderPath, {
+          ...options,
+          checkExisting: 'error',
+        })
+      ).rejects.toThrow(
+        `Package ${mockPackageJson.name}@${mockPackageJson.version} already exists in registry.`
+      );
+
+      // Verify check was performed but publish was not attempted
+      expect(spawn.spawnAsync).toHaveBeenCalledWith('npm', [
+        'view',
+        `${mockPackageJson.name}@${mockPackageJson.version}`,
+        'version',
+      ]);
+      expect(spawn.spawnAsync).not.toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['publish'])
+      );
+    });
+
+    it('should proceed with publishing when package does not exist', async () => {
+      const { absoluteDistFolderPath, options, mockPackageJson } =
+        versionCheckSetup({
+          options: {
+            ...defaultOption,
+            checkExisting: 'warning',
+          },
+          npmViewResult: () => Promise.reject({ code: 'E404' }),
+          npmPublishResult: () => Promise.resolve(),
+        });
+
+      await engine.run(absoluteDistFolderPath, {
+        ...options,
+        checkExisting: 'warning',
+      });
+
+      expect(spawn.spawnAsync).toHaveBeenNthCalledWith(1, 'npm', [
+        'view',
+        `${mockPackageJson.name}@${mockPackageJson.version}`,
+        'version',
+      ]);
+
+      expect(spawn.spawnAsync).toHaveBeenNthCalledWith(2, 'npm', [
+        'publish',
+        absoluteDistFolderPath,
+        '--access',
+        'public',
+      ]);
+
+      expect(spawn.spawnAsync).toHaveBeenCalledTimes(2);
     });
   });
 });

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
@@ -70,9 +70,12 @@ export async function run(
 
       if (exists) {
         if (options.checkExisting === 'error') {
-          throw new Error(
-            `Package ${packageInfo.name}@${packageInfo.version} already exists in registry.`
-          );
+          const message = `Package ${packageInfo.name}@${
+            packageInfo.version
+          } already exists in registry ${
+            options.registry ? options.registry : ''
+          }.`;
+          throw new Error(message);
         } else {
           logger.warn(
             `Package ${packageInfo.name}@${packageInfo.version} already exists in registry. Skipping  publish.`

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
@@ -72,8 +72,8 @@ export async function run(
         if (options.checkExisting === 'error') {
           const message = `Package ${packageInfo.name}@${
             packageInfo.version
-          } already exists in registry ${
-            options.registry ? options.registry : ''
+          } already exists in registry${
+            options.registry ? ` ${options.registry}` : ''
           }.`;
           throw new Error(message);
         } else {

--- a/packages/ngx-deploy-npm/src/executors/deploy/schema.d.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/schema.d.ts
@@ -27,4 +27,8 @@ export interface DeployExecutorOptions {
    * For testing: Run through without making any changes. Execute with --dry-run and nothing will happen.
    */
   dryRun?: boolean;
+  /**
+   * Check if the package version already exists before publishing
+   */
+  checkExisting?: 'error' | 'warning';
 }

--- a/packages/ngx-deploy-npm/src/executors/deploy/schema.json
+++ b/packages/ngx-deploy-npm/src/executors/deploy/schema.json
@@ -36,6 +36,11 @@
       "type": "boolean",
       "description": "For testing: Run through without making any changes. Execute with --dry-run and nothing will happen.",
       "default": false
+    },
+    "checkExisting": {
+      "type": "string",
+      "description": "How to handle existing package versions: 'warning' to continue with a warning, 'error' to abort publishing",
+      "enum": ["warning", "error"]
     }
   },
   "required": ["distFolderPath"]


### PR DESCRIPTION
fixes: https://github.com/bikecoders/ngx-deploy-npm/issues/666
fixes: https://github.com/bikecoders/ngx-deploy-npm/issues/508

This commit adds a new optional flag `checkExisting` that allows users to verify if a package version already exists in the registry before publishing. When enabled, it will:
- Check the package.json for name and version
- Query npm registry for existing versions
- Skip publishing if version already exists
- Default to false to maintain backward compatibility and avoid regression
- Add test
- Add documentation

This helps prevent accidental republishing package and having issue (403) when trying to republish a version that is already pushed (on gitlab for example)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: https://github.com/bikecoders/ngx-deploy-npm/issues/666

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
