### PR TITLE
ci: enable sonarqube analysis for contributors

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -1,4 +1,4 @@
-name: PR's
+name: PRs
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -21,7 +21,9 @@ jobs:
       - uses: ./.github/actions/setup
 
       - name: Execute commitlint
-        run: npx commitlint --from=origin/${{ github.base_ref }}
+        run: npx commitlint --from="origin/$BASE_REF"
+    env:
+      BASE_REF: ${{ github.base_ref }}
 
   check-file-format:
     name: Check files changes follow guidelines
@@ -36,25 +38,3 @@ jobs:
   backwards-compatibility-test:
     needs: [pr-test]
     uses: ./.github/workflows/backwards-compatibility-test.yml
-
-  pr-analysis:
-    name: SonarCloud Pr Analysis
-    runs-on: ubuntu-latest
-    needs: pr-test
-    steps:
-      - uses: actions/checkout@v4
-        with:
-          fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
-
-      # Download reports
-      - uses: ./.github/actions/download-coverage-report
-      - uses: ./.github/actions/download-lint-report
-
-      - name: SonarCloud Scan
-        uses: SonarSource/sonarcloud-github-action@master
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # Needed to get PR information, if any
-          SONAR_TOKEN: ${{ secrets.SONARQUBE_SCANNER }}
-        with:
-          args: >
-            -Dsonar.pullrequest.key=${{ github.env.PR_NUMBER }}

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -1,0 +1,33 @@
+name: Sonar for PRs
+on:
+  workflow_run:
+    workflows: ['PRs']
+    types: [requested]
+jobs:
+  sonar:
+    name: Sonar
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    if: github.event.workflow_run.conclusion == 'success'
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          repository: ${{ github.event.workflow_run.head_repository.full_name }}
+          ref: ${{ github.event.workflow_run.head_branch }}
+          fetch-depth: 0
+
+      # Download reports
+      - uses: ./.github/actions/download-coverage-report
+      - uses: ./.github/actions/download-lint-report
+
+      - name: SonarCloud Scan
+        uses: sonarsource/sonarcloud-github-action@master
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
+        with:
+          args: >
+            -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
+            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
+            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
+            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: #671 

## What is the new behavior?

Adding a new workflow `sonar-pr.yml` for SonarCloud analysis on successful PR runs. This new workflow is triggered by `workflow_run`, which allows secrets to be shared with PR's from forked repos.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

According to the [documentation for `workflow_run`](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/events-that-trigger-workflows#workflow_run), the workflow must be on the main branch. This requirement makes it impossible to test the new CI configuration. We need to merge this PR to see the results.
