### PR TITLE
ci: make commit sha consistent across workflows

### DIFF
--- a/.github/workflows/basic-test.yml
+++ b/.github/workflows/basic-test.yml
@@ -2,6 +2,9 @@ name: Essential Test
 
 on: workflow_call
 
+env:
+  COMMIT_SHA: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || github.sha }}
+
 jobs:
   lint:
     runs-on: ubuntu-latest
@@ -18,7 +21,7 @@ jobs:
       - name: Archive lint report results
         uses: actions/upload-artifact@v4
         with:
-          name: lint-report-${{ github.sha }}
+          name: lint-report-${{ env.COMMIT_SHA }}
           path: reports
 
   build:
@@ -32,13 +35,14 @@ jobs:
       - name: Archive build result
         uses: actions/upload-artifact@v4
         with:
-          name: library-dist-${{ github.sha }}
+          name: library-dist-${{ env.COMMIT_SHA }}
           path: dist
 
   unit-test:
     strategy:
       matrix:
-        os: [ubuntu-latest, windows-latest]
+        os: [ubuntu-latest] # to have test faster
+        # os: [ubuntu-latest, windows-latest]
         node-version: [20, 22]
     runs-on: ${{ matrix.os }}
     steps:
@@ -61,5 +65,5 @@ jobs:
         name: Archive coverage report
         uses: actions/upload-artifact@v4
         with:
-          name: ngx-deploy-npm-coverage-report-${{ github.sha }}
+          name: ngx-deploy-npm-coverage-report-${{ env.COMMIT_SHA }}
           path: coverage/packages/ngx-deploy-npm/lcov.info

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -35,12 +35,59 @@ jobs:
             JSON.stringify(${{ github.event.workflow_run }}, null, 2)
 
       # Download reports
-      - uses: ./.github/actions/download-coverage-report
+      - name: 'Download reports'
+        uses: actions/github-script@v6
         with:
-          sha: ${{ github.event.workflow_run.head_sha }}
-      - uses: ./.github/actions/download-lint-report
-        with:
-          sha: ${{ github.event.workflow_run.head_sha }}
+          script: |
+            async function downloadArtifact(artifactName) {
+              console.log(`Looking for artifact: ${artifactName}`);
+
+              let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 run_id: context.payload.workflow_run.id,
+              });
+
+              console.log('Available artifacts:', allArtifacts.data.artifacts.map(a => a.name));
+
+              let matchArtifact = allArtifacts.data.artifacts.find((artifact) => {
+                return artifact.name === artifactName;
+              });
+
+              if (!matchArtifact) {
+                throw new Error(`Artifact "${artifactName}" not found!`);
+              }
+
+              let download = await github.rest.actions.downloadArtifact({
+                 owner: context.repo.owner,
+                 repo: context.repo.repo,
+                 artifact_id: matchArtifact.id,
+                 archive_format: 'zip',
+              });
+
+              let fs = require('fs');
+              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${artifactName}.zip`, Buffer.from(download.data));
+
+              return artifactName;
+            }
+
+            const sha = context.payload.workflow_run.head_sha;
+
+            // Download both artifacts
+            await Promise.all([
+              downloadArtifact(`ngx-deploy-npm-coverage-report-${sha}`),
+              downloadArtifact(`lint-report-${sha}`)
+            ]);
+
+      - name: 'Extract reports'
+        run: |
+          # Extract coverage report
+          mkdir -p coverage/packages/ngx-deploy-npm
+          unzip ngx-deploy-npm-coverage-report-*.zip -d coverage/packages/ngx-deploy-npm
+
+          # Extract lint report
+          mkdir -p reports
+          unzip lint-report-*.zip -d reports
 
       - name: SonarCloud Scan
         uses: sonarsource/sonarcloud-github-action@master


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying or link to a relevant issue. -->

Issue Number: #671 

Turns out what:

> Yes, `git log -1 --format=%H` should be equal to `github.sha` in the CI runtime if you're running the workflow on the same commit. However, there are a few scenarios where they might not match:

- **Pull Request workflows:** GitHub creates a merge commit by merging your branch with the target branch. In this case:
  - Your local: `your-branch-commit`
  - GitHub Actions: `temporary-merge-commit`


## What is the new behavior?

The new behavior ensures that the commit SHA is consistent across different GitHub Actions workflows. This addresses scenarios in pull request workflows where GitHub creates a temporary merge commit, causing discrepancies between the local branch commit SHA and the one used in the GitHub Actions environment. As a result, the commit SHA will now reliably match between the local branch and the CI runtime, preventing inconsistencies and potential issues in the workflows.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
