### PR TITLE
build: align @types/node with Node 24

### DIFF
--- a/.agents/skills/nx-migrate-workspace/SKILL.md
+++ b/.agents/skills/nx-migrate-workspace/SKILL.md
@@ -2,8 +2,8 @@
 name: nx-migrate-workspace
 description: >-
   Upgrade this Nx workspace one major per run with nx migrate, then update
-  backwards-compat CI, basic-test/e2e Node matrices, and .nvmrc from the workspace
-  version after migrations finish.
+  backwards-compat CI, basic-test/e2e Node matrices, .nvmrc, and @types/node from the
+  workspace version after migrations finish.
   Never jump multiple nx migrate majors in one run. Use when updating
   or migrating Nx.
 ---
@@ -15,7 +15,7 @@ The user reviews all changes — **never commit, push, or open a PR** unless ask
 ## Hard rules
 
 1. **`nx migrate` one major per run** — e.g. on 21.x use `nx migrate 22` only; stop and summarize; repeat later for 23.
-2. **Compatibility CI last** — update [backwards-compatibility-test.yml](.github/workflows/backwards-compatibility-test.yml), [basic-test.yml](.github/workflows/basic-test.yml) (unit-test matrix), [e2e-test.yml](.github/workflows/e2e-test.yml), and [.nvmrc](.nvmrc) only **after** `nx migrate --run-migrations`, using the version now in `package.json`.
+2. **Compatibility CI last** — update [backwards-compatibility-test.yml](.github/workflows/backwards-compatibility-test.yml), [basic-test.yml](.github/workflows/basic-test.yml) (unit-test matrix), [e2e-test.yml](.github/workflows/e2e-test.yml), [.nvmrc](.nvmrc), and root `package.json` `devDependencies["@types/node"]` only **after** `nx migrate --run-migrations`, using the version now in `package.json`.
 3. **Do not skip ahead in CI** — matrix rows must not target Nx majors above what `package.json` has after this run.
 4. **`npm exec nx …`** — this repo uses npm.
 5. **No git commits.**
@@ -36,7 +36,7 @@ One major per run:
 - [ ] 3. npm install
 - [ ] 4. Migrate coupled plugins + npm install
 - [ ] 5. nx migrate --run-migrations
-- [ ] 6. Node compatibility (.nvmrc + backwards-compat + basic-test + e2e-test) — after step 5; see reference
+- [ ] 6. Node compatibility (.nvmrc + @types/node + backwards-compat + basic-test + e2e-test) — after step 5; see reference
 - [ ] 7. nx build / test / lint ngx-deploy-npm
 - [ ] 8. Summarize for review (no commit)
 ```
@@ -94,6 +94,8 @@ Do **not** replace `'previous'` with a numeric version. **Keep the `previous` ta
 
 Also update [basic-test.yml](.github/workflows/basic-test.yml) (`unit-test` job) and [e2e-test.yml](.github/workflows/e2e-test.yml): set `node-version` to **every** Node major Nx documents for the **workspace** major (same list as the `''` tier in backwards-compat), e.g. Nx 22.x → `[20, 22, 24, 26]`. Update workflow comments when the workspace major changes.
 
+Set root `devDependencies["@types/node"]` to the **same major as `.nvmrc`** (e.g. `.nvmrc` `24` → `^24.x` with a current patch from `npm view @types/node@24 version`). `nx migrate` often leaves stale `@types/node` (e.g. `^20.x`); fix it in this step, not only when `.nvmrc` changes.
+
 ### 7 — Validate
 
 ```bash
@@ -106,7 +108,7 @@ Optional: `npm exec nx smoke ngx-deploy-npm-e2e`
 
 ### 8 — Handoff
 
-Include: Nx old → new; files changed; `.nvmrc` rationale; matrix tier counts; peer warnings; remaining majors; suggested commit message (text only).
+Include: Nx old → new; files changed; `.nvmrc` and `@types/node` rationale; matrix tier counts; peer warnings; remaining majors; suggested commit message (text only).
 
 ## Optional follow-ups
 

--- a/.agents/skills/nx-migrate-workspace/references/node-compatibility.md
+++ b/.agents/skills/nx-migrate-workspace/references/node-compatibility.md
@@ -5,6 +5,7 @@
 **Why last:** `package.json` already has the new Nx version. Update from **that current state**:
 
 - [.nvmrc](../../../.nvmrc)
+- Root [package.json](../../../package.json) `devDependencies["@types/node"]` (major must match `.nvmrc`)
 - [.github/workflows/backwards-compatibility-test.yml](../../../.github/workflows/backwards-compatibility-test.yml)
 - [.github/workflows/basic-test.yml](../../../.github/workflows/basic-test.yml) (`unit-test` matrix)
 - [.github/workflows/e2e-test.yml](../../../.github/workflows/e2e-test.yml)
@@ -114,6 +115,17 @@ Retain Node rows or infer from the closest documented major.
 
 Nx docs row for **workspace major** (from `package.json`) ∩ **Node LTS** from [Node.js Releases](https://nodejs.org/en/about/previous-releases). One integer line (`24`).
 
+## `@types/node` (root `package.json`)
+
+Match the **major** in `.nvmrc` — not whatever `nx migrate` last wrote (often an older major).
+
+```bash
+# .nvmrc is 24 → align typings
+npm view @types/node@24 version
+```
+
+Set `devDependencies["@types/node"]` to `^<major>.<latest-patch>` (e.g. `^24.12.4` when `.nvmrc` is `24`). Run `npm install` if you change it outside the main migrate install step.
+
 ## Checklist
 
 - [ ] Migrations finished; `package.json` nx version is the new major for this run
@@ -123,5 +135,6 @@ Nx docs row for **workspace major** (from `package.json`) ∩ **Node LTS** from 
 - [ ] Minimum pin: latest patch on npm for minimum supported major
 - [ ] No duplicate pairs; no tiers above workspace major
 - [ ] `.nvmrc` matches workspace major ∩ LTS
+- [ ] Root `@types/node` major matches `.nvmrc` (bump if `nx migrate` left an older major)
 - [ ] [basic-test.yml](../../../.github/workflows/basic-test.yml) and [e2e-test.yml](../../../.github/workflows/e2e-test.yml) `node-version` list all nodes for workspace major
 - [ ] Handoff lists resolved versions per tier (no commit)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 # General Guidelines for working with Nx
 
 - For navigating/exploring the workspace, invoke the `nx-workspace` skill first - it has patterns for querying projects, targets, and dependencies
-- For upgrading the Nx workspace version, invoke the `nx-migrate-workspace` skill - `nx migrate` one major at a time; after migrations finish, update backwards-compat CI, basic-test/e2e Node matrices, and `.nvmrc` from the version in `package.json`
+- For upgrading the Nx workspace version, invoke the `nx-migrate-workspace` skill - `nx migrate` one major at a time; after migrations finish, update backwards-compat CI, basic-test/e2e Node matrices, `.nvmrc`, and root `@types/node` (major aligned with `.nvmrc`) from the version in `package.json`
 - When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through `nx` (i.e. `nx run`, `nx run-many`, `nx affected`) instead of using the underlying tooling directly
 - Prefix nx commands with the workspace's package manager (e.g., `pnpm nx build`, `npm exec nx test`) - avoids using globally installed CLI
 - You have access to the Nx MCP server and its tools, use them to help the user

--- a/package-lock.json
+++ b/package-lock.json
@@ -24,7 +24,7 @@
         "@nx/plugin": "22.7.2",
         "@nx/workspace": "22.7.2",
         "@types/jest": "30.0.0",
-        "@types/node": "^20.14.8",
+        "@types/node": "^24.12.4",
         "commitizen": "4.3.1",
         "create-nx-workspace": "22.7.2",
         "cz-conventional-changelog": "3.3.0",
@@ -4238,13 +4238,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "20.19.4",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.4.tgz",
-      "integrity": "sha512-OP+We5WV8Xnbuvw0zC2m4qfB/BJvjyCwtNjhHdJxV1639SGSKrLmJkc3fMnp2Qy8nJyHp8RO6umxELN/dS1/EA==",
+      "version": "24.12.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.12.4.tgz",
+      "integrity": "sha512-GUUEShf+PBCGW2KaXwcIt3Yk+e3pkKwWKb9GSyM9WQVE+ep2jzmHdGsHzu4wgcZy5fN9FBdVzjpBQsYlpfpgLA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "undici-types": "~6.21.0"
+        "undici-types": "~7.16.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -15342,9 +15342,9 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "6.21.0",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
-      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "version": "7.16.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
+      "integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "@nx/plugin": "22.7.2",
     "@nx/workspace": "22.7.2",
     "@types/jest": "30.0.0",
-    "@types/node": "^20.14.8",
+    "@types/node": "^24.12.4",
     "commitizen": "4.3.1",
     "create-nx-workspace": "22.7.2",
     "cz-conventional-changelog": "3.3.0",


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

Root `devDependencies["@types/node"]` was `^20.14.8` while the workspace runs Node 24 (`.nvmrc`). That mismatch can cause incorrect TypeScript typings during build and editor checks.

Issue Number: N/A

## What is the new behavior?

- Bump `@types/node` to `^24.12.4` and refresh the lockfile.
- Extend `nx-migrate-workspace` (skill, node-compatibility reference, and `AGENTS.md`) so future Nx upgrades also align `@types/node` with `.nvmrc`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

CI build/lint should pick up the corrected typings automatically; no plugin API changes.