### PR TITLE
docs: add main branch protection to nx-migrate Node step

### DIFF
--- a/.agents/skills/nx-migrate-workspace/SKILL.md
+++ b/.agents/skills/nx-migrate-workspace/SKILL.md
@@ -2,8 +2,9 @@
 name: nx-migrate-workspace
 description: >-
   Upgrade this Nx workspace one major per run with nx migrate, then update
-  backwards-compat CI, basic-test/e2e Node matrices, .nvmrc, and @types/node from the
-  workspace version after migrations finish.
+  backwards-compat CI, basic-test/e2e Node matrices, .nvmrc, @types/node, and
+  GitHub main required status checks for .nvmrc Node from the workspace version
+  after migrations finish.
   Never jump multiple nx migrate majors in one run. Use when updating
   or migrating Nx.
 ---
@@ -15,7 +16,7 @@ The user reviews all changes — **never commit, push, or open a PR** unless ask
 ## Hard rules
 
 1. **`nx migrate` one major per run** — e.g. on 21.x use `nx migrate 22` only; stop and summarize; repeat later for 23.
-2. **Compatibility CI last** — update [backwards-compatibility-test.yml](.github/workflows/backwards-compatibility-test.yml), [basic-test.yml](.github/workflows/basic-test.yml) (unit-test matrix), [e2e-test.yml](.github/workflows/e2e-test.yml), [.nvmrc](.nvmrc), and root `package.json` `devDependencies["@types/node"]` only **after** `nx migrate --run-migrations`, using the version now in `package.json`.
+2. **Compatibility CI last** — update [backwards-compatibility-test.yml](.github/workflows/backwards-compatibility-test.yml), [basic-test.yml](.github/workflows/basic-test.yml) (unit-test matrix), [e2e-test.yml](.github/workflows/e2e-test.yml), [.nvmrc](.nvmrc), root `package.json` `devDependencies["@types/node"]`, and **`main` branch protection** required contexts for `.nvmrc` Node only **after** `nx migrate --run-migrations`, using the version now in `package.json`.
 3. **Do not skip ahead in CI** — matrix rows must not target Nx majors above what `package.json` has after this run.
 4. **`npm exec nx …`** — this repo uses npm.
 5. **No git commits.**
@@ -36,7 +37,7 @@ One major per run:
 - [ ] 3. npm install
 - [ ] 4. Migrate coupled plugins + npm install
 - [ ] 5. nx migrate --run-migrations
-- [ ] 6. Node compatibility (.nvmrc + @types/node + backwards-compat + basic-test + e2e-test) — after step 5; see reference
+- [ ] 6. Node compatibility (.nvmrc + @types/node + backwards-compat + basic-test + e2e-test + main branch protection) — after step 5; see references
 - [ ] 7. nx build / test / lint ngx-deploy-npm
 - [ ] 8. Summarize for review (no commit)
 ```
@@ -96,6 +97,8 @@ Also update [basic-test.yml](.github/workflows/basic-test.yml) (`unit-test` job)
 
 Set root `devDependencies["@types/node"]` to the **same major as `.nvmrc`** (e.g. `.nvmrc` `24` → `^24.x` with a current patch from `npm view @types/node@24 version`). `nx migrate` often leaves stale `@types/node` (e.g. `^20.x`); fix it in this step, not only when `.nvmrc` changes.
 
+When `.nvmrc` changes, update **`main` required status checks** so unit/e2e matrix gates use the new Node (ubuntu + windows only). Follow [references/branch-protection.md](references/branch-protection.md) — use `ngx-deploy-npm-github-repo-admin` MCP (`get_branch_protection` / `update_branch_protection`).
+
 ### 7 — Validate
 
 ```bash
@@ -108,7 +111,7 @@ Optional: `npm exec nx smoke ngx-deploy-npm-e2e`
 
 ### 8 — Handoff
 
-Include: Nx old → new; files changed; `.nvmrc` and `@types/node` rationale; matrix tier counts; peer warnings; remaining majors; suggested commit message (text only).
+Include: Nx old → new; files changed; `.nvmrc` and `@types/node` rationale; matrix tier counts; whether `main` branch protection contexts were updated; peer warnings; remaining majors; suggested commit message (text only).
 
 ## Optional follow-ups
 

--- a/.agents/skills/nx-migrate-workspace/references/branch-protection.md
+++ b/.agents/skills/nx-migrate-workspace/references/branch-protection.md
@@ -1,0 +1,71 @@
+# Branch protection (`main`) after Node / `.nvmrc` changes
+
+**When:** same migration run as [node-compatibility.md](node-compatibility.md) step 6 — whenever `.nvmrc` changes or the workspace standard Node major changes.
+
+**Why:** CI matrix jobs report check contexts like `pr-test / unit-test (ubuntu-latest, 24)`. If `main` still requires an old Node (e.g. `…, 20)`), PRs can pass CI on the new Node but stay unmergeable.
+
+**Repo:** `bikecoders/ngx-deploy-npm`, branch **`main` only**. This repo uses **classic legacy** branch protection (not rulesets).
+
+## What to require on `main`
+
+Gate merges on:
+
+- `pr-test / build`
+- `pr-test / lint`
+- `SonarCloud Code Analysis`
+- `Check commit message follows guidelines`
+- `Check files changes follow guidelines`
+- **Ubuntu + Windows** unit and e2e for **`.nvmrc` Node only** — not every matrix Node version
+
+Example when `.nvmrc` is `24`:
+
+| Job family | Required contexts                                                                           |
+| ---------- | ------------------------------------------------------------------------------------------- |
+| Unit test  | `pr-test / unit-test (ubuntu-latest, 24)`, `pr-test / unit-test (windows-latest, 24)`       |
+| E2E        | `pr-e2e-test / e2e-test (ubuntu-latest, 24)`, `pr-e2e-test / e2e-test (windows-latest, 24)` |
+
+Lint/build use `.nvmrc` via setup (no matrix). Do **not** add required checks for other matrix rows (20, 22, 26) unless you intentionally want full-matrix gating.
+
+## How to derive context names
+
+Pattern: `{caller-job} / {matrix-job} ({os}, {node})`
+
+- Caller jobs come from [pr.yml](../../../.github/workflows/pr.yml): `pr-test` (basic-test), `pr-e2e-test` (e2e-test).
+- Matrix jobs: `unit-test`, `e2e-test`.
+- `{node}` = integer from [.nvmrc](../../../.nvmrc).
+
+Confirm names on a recent green PR with `user-github` → `pull_request_read` → `get_check_runs` before updating protection.
+
+## How to apply (preferred: repo-admin MCP)
+
+Use **`ngx-deploy-npm-github-repo-admin`** (`CallMcpTool`, server `user-ngx-deploy-npm-github-repo-admin`):
+
+1. **`get_branch_protection`** — `owner: bikecoders`, `repo: ngx-deploy-npm`, `branch: main`. Read `required_status_checks.contexts`.
+2. Build the **full** new `contexts` list (GitHub replaces the array; it does not merge).
+3. **`update_branch_protection`** — pass `contexts` and `dry_run: true` first, then `dry_run: false` to apply. The tool preserves other protection fields from GET.
+
+Do **not** use `apply_ruleset` on this repo unless migrating off legacy protection — rulesets would stack on classic rules.
+
+### Fallback
+
+- GitHub UI: Settings → Branches → `main` → required status checks.
+- `gh api` GET/PATCH `repos/bikecoders/ngx-deploy-npm/branches/main/protection` with the full protection body from GET.
+
+## Node bump template (e.g. 20 → 24)
+
+| Remove                                        | Add                                           |
+| --------------------------------------------- | --------------------------------------------- |
+| `pr-test / unit-test (ubuntu-latest, 20)`     | `pr-test / unit-test (ubuntu-latest, 24)`     |
+| `pr-test / unit-test (windows-latest, 20)`    | `pr-test / unit-test (windows-latest, 24)`    |
+| `pr-e2e-test / e2e-test (ubuntu-latest, 20)`  | `pr-e2e-test / e2e-test (ubuntu-latest, 24)`  |
+| `pr-e2e-test / e2e-test (windows-latest, 20)` | `pr-e2e-test / e2e-test (windows-latest, 24)` |
+
+Keep the five non-matrix checks unchanged.
+
+## Checklist
+
+- [ ] `.nvmrc` and CI matrices updated per [node-compatibility.md](node-compatibility.md)
+- [ ] Check context names verified on a recent PR (`get_check_runs`)
+- [ ] `get_branch_protection` on `main` — no stale `…, <old-nvmrc>)` contexts
+- [ ] `update_branch_protection` applied (or confirmed already correct)
+- [ ] Handoff mentions branch protection if `.nvmrc` changed

--- a/.agents/skills/nx-migrate-workspace/references/node-compatibility.md
+++ b/.agents/skills/nx-migrate-workspace/references/node-compatibility.md
@@ -9,6 +9,7 @@
 - [.github/workflows/backwards-compatibility-test.yml](../../../.github/workflows/backwards-compatibility-test.yml)
 - [.github/workflows/basic-test.yml](../../../.github/workflows/basic-test.yml) (`unit-test` matrix)
 - [.github/workflows/e2e-test.yml](../../../.github/workflows/e2e-test.yml)
+- **`main` branch protection** required status checks — see [branch-protection.md](branch-protection.md)
 
 `nx migrate <major>` is still **one major per run**; this section only aligns CI/`.nvmrc` with whatever major is in the workspace **now**.
 
@@ -137,4 +138,5 @@ Set `devDependencies["@types/node"]` to `^<major>.<latest-patch>` (e.g. `^24.12.
 - [ ] `.nvmrc` matches workspace major ∩ LTS
 - [ ] Root `@types/node` major matches `.nvmrc` (bump if `nx migrate` left an older major)
 - [ ] [basic-test.yml](../../../.github/workflows/basic-test.yml) and [e2e-test.yml](../../../.github/workflows/e2e-test.yml) `node-version` list all nodes for workspace major
+- [ ] `main` branch protection: unit/e2e required contexts use `.nvmrc` on ubuntu + windows ([branch-protection.md](branch-protection.md))
 - [ ] Handoff lists resolved versions per tier (no commit)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@
 # General Guidelines for working with Nx
 
 - For navigating/exploring the workspace, invoke the `nx-workspace` skill first - it has patterns for querying projects, targets, and dependencies
-- For upgrading the Nx workspace version, invoke the `nx-migrate-workspace` skill - `nx migrate` one major at a time; after migrations finish, update backwards-compat CI, basic-test/e2e Node matrices, `.nvmrc`, and root `@types/node` (major aligned with `.nvmrc`) from the version in `package.json`
+- For upgrading the Nx workspace version, invoke the `nx-migrate-workspace` skill - `nx migrate` one major at a time; after migrations finish, update backwards-compat CI, basic-test/e2e Node matrices, `.nvmrc`, root `@types/node` (major aligned with `.nvmrc`), and `main` required status checks for `.nvmrc` Node from the version in `package.json`
 - When running tasks (for example build, lint, test, e2e, etc.), always prefer running the task through `nx` (i.e. `nx run`, `nx run-many`, `nx affected`) instead of using the underlying tooling directly
 - Prefix nx commands with the workspace's package manager (e.g., `pnpm nx build`, `npm exec nx test`) - avoids using globally installed CLI
 - You have access to the Nx MCP server and its tools, use them to help the user


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

When upgrading the Nx workspace and Node version (`.nvmrc`), the nx-migrate skill updates CI matrices and `.nvmrc` but does not remind agents to align **legacy branch protection** on `main`. Required status checks can stay on an old Node matrix context (e.g. `unit-test (ubuntu-latest, 20)`), so PRs pass CI on Node 24 while merge stays blocked.

Issue Number: N/A

## What is the new behavior?

- New reference [branch-protection.md](.agents/skills/nx-migrate-workspace/references/branch-protection.md) documents when and how to update `main` required checks after `.nvmrc` changes.
- `nx-migrate-workspace` skill step 6 and handoff include branch protection (ubuntu + windows unit/e2e for `.nvmrc` Node only).
- `node-compatibility.md` checklist and `AGENTS.md` cross-link the runbook.
- Runbook prefers `ngx-deploy-npm-github-repo-admin` MCP (`get_branch_protection` / `update_branch_protection`).

`main` protection on the repo already uses Node 24 contexts; this PR is documentation only.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Related: Node 24 standard on `main` (#731). Branch protection contexts were verified via repo-admin MCP before this doc update.