### PR TITLE
chore(ci): bump actions/checkout from v4 to v6

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -12,7 +12,7 @@ runs:
   using: composite
   steps:
     - name: Checkout all commits
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         token: ${{ inputs.git_bot_token || github.token }}
         fetch-depth: 0

--- a/.github/workflows/basic-test.yml
+++ b/.github/workflows/basic-test.yml
@@ -7,7 +7,7 @@ jobs:
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
       - name: Lint
@@ -25,7 +25,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
       - run: npx nx build ngx-deploy-npm
@@ -44,7 +44,7 @@ jobs:
         node-version: [20, 22, 24, 26]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/compatibility-observability.yml
+++ b/.github/workflows/compatibility-observability.yml
@@ -8,7 +8,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
       - run: npx nx build ngx-deploy-npm

--- a/.github/workflows/e2e-test.yml
+++ b/.github/workflows/e2e-test.yml
@@ -12,7 +12,7 @@ jobs:
         node-version: [20, 22, 24, 26]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ matrix.node-version }}

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -17,7 +17,7 @@ jobs:
     name: Check commit message follows guidelines
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
       - name: Execute commitlint
@@ -29,7 +29,7 @@ jobs:
     name: Check files changes follow guidelines
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
       - name: Check if Prettier was run
@@ -46,7 +46,7 @@ jobs:
   #   runs-on: ubuntu-latest
   #   needs: pr-test
   #   steps:
-  #     - uses: actions/checkout@v4
+  #     - uses: actions/checkout@v6
   #       with:
   #         fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
   #     # Download reports

--- a/.github/workflows/publishment.yml
+++ b/.github/workflows/publishment.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: test
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0 # Shallow clones should be disabled for a better relevancy of analysis
 
@@ -37,7 +37,7 @@ jobs:
   release-preliminar:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
 
       - name: Preliminar Version
@@ -48,7 +48,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [release-preliminar, e2e-test, test, backwards-compatibility-test]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           git_bot_token: ${{ secrets.GIT_BOT_TOKEN }}

--- a/.github/workflows/smoke-test-nx-workspace.yml
+++ b/.github/workflows/smoke-test-nx-workspace.yml
@@ -38,7 +38,7 @@ jobs:
             echo "Using default Nx version from package.json file"
           fi
 
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           node-version: ${{ inputs.node-version }}

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -10,7 +10,7 @@ jobs:
     timeout-minutes: 30
     if: github.event.workflow_run.conclusion == 'success'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}

--- a/.github/workflows/test-nx-next.yml
+++ b/.github/workflows/test-nx-next.yml
@@ -8,7 +8,7 @@ jobs:
   lint-next:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/migrate
         with:
@@ -19,7 +19,7 @@ jobs:
   build-next:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/migrate
         with:
@@ -30,7 +30,7 @@ jobs:
   test-next:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/migrate
         with:
@@ -41,7 +41,7 @@ jobs:
   e2e-next:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
       - uses: ./.github/actions/migrate
         with:


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

GitHub Actions workflows and the composite setup action use `actions/checkout@v4`.

Issue Number: N/A

## What is the new behavior?

All checkouts use `actions/checkout@v6` (Node 24 runtime; credentials stored under `$RUNNER_TEMP` via `includeIf.gitdir` instead of `http.*.extraheader` in `.git/config`). No `with:` input changes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Low risk for this repo: every job runs on GitHub-hosted runners; no `container:` jobs, `ssh-key`, or `submodules`. Workflows worth watching in CI: `sonar-pr` (fork `repository` + `ref`), `publishment` (`GIT_BOT_TOKEN` via setup), and setup jobs using `fetch-depth: 0`.