### PR TITLE
ci: publish releases with npm trusted publishing (OIDC)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -7,6 +7,10 @@ inputs:
   git_bot_token:
     description: Git Bot token used to push to protected branches because github token can't
     required: false
+  package-manager-cache:
+    description: Enable npm cache in setup-node. Disable for release publishes (npm recommendation).
+    required: false
+    default: 'true'
 
 runs:
   using: composite
@@ -39,12 +43,9 @@ runs:
       uses: actions/setup-node@v6
       with:
         node-version: ${{ env.NODE_VERSION }}
-        cache: 'npm'
-        # This doesn't just set the registry url, but also sets
-        # the right configuration in .npmrc that reads NPM token
-        # from NPM_AUTH_TOKEN environment variable.
-        # It actually creates a .npmrc in a temporary folder
-        # and sets the NPM_CONFIG_USERCONFIG environment variable.
+        package-manager-cache: ${{ inputs.package-manager-cache == 'true' }}
+        # Sets registry-url for npm publish. Release uses OIDC trusted publishing
+        # (no NODE_AUTH_TOKEN); other jobs may still use NODE_AUTH_TOKEN when set.
         registry-url: https://registry.npmjs.org
     - name: npm install
       shell: bash

--- a/.github/workflows/publishment.yml
+++ b/.github/workflows/publishment.yml
@@ -47,26 +47,22 @@ jobs:
     environment: production
     runs-on: ubuntu-latest
     needs: [release-preliminar, e2e-test, test, backwards-compatibility-test]
+    permissions:
+      id-token: write # OIDC for npm trusted publishing
+      contents: read
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
         with:
           git_bot_token: ${{ secrets.GIT_BOT_TOKEN }}
+          package-manager-cache: false
 
       - uses: ./.github/actions/download-build
 
-      - name: Check npm credentials
-        run: npm whoami
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-          # Use npx instead of yarn because yarn automagically sets NPM_* environment variables
-          # like NPM_CONFIG_REGISTRY so npm publish ends up ignoring the .npmrc file
-          # which is set up by `setup-node` action.
-
+      # npm trusted publishing (OIDC): no NPM_TOKEN. Configure the trusted
+      # publisher on npmjs.com for workflow publishment.yml (see contributors doc).
       - name: Version and Publishment
         run: npx nx version ngx-deploy-npm
-        env:
-          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 
       - name: Tag last-release
         run: git tag --force last-release


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

The `release` job in `publishment.yml` authenticates to npm with `NPM_TOKEN` via `NODE_AUTH_TOKEN`. When the npm account requires 2FA for writes, publish fails in CI with `EOTP` (one-time password required).

Issue Number: N/A

## What is the new behavior?

The `release` job uses [npm trusted publishing](https://docs.npmjs.com/trusted-publishers) (OIDC):

- `permissions.id-token: write` on the `release` job
- No `NPM_TOKEN` / `NODE_AUTH_TOKEN` for publish
- `setup` action supports optional `package-manager-cache` (disabled on release per npm guidance)
- Contributor docs describe one-time npmjs.com trusted publisher setup

Trusted publisher on npmjs.com must be configured for `bikecoders/ngx-deploy-npm`, workflow `publishment.yml`, environment `production`, action `npm publish`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

After the first successful release on `main`, maintainers can remove the `NPM_TOKEN` GitHub secret if it is no longer used elsewhere.

## Test plan

- [x] Merge and monitor CI on this PR (workflows that do not publish are unchanged)
- [x] After merge to `main`, approve the `production` environment and confirm the `release` job publishes without `EOTP`
- [x] Confirm the new version appears on https://www.npmjs.com/package/ngx-deploy-npm