### PR TITLE
fix(ngx-deploy-npm): resolve open SonarCloud static analysis issues

### DIFF
--- a/packages/ngx-deploy-npm/src/executors/deploy/actions.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/actions.ts
@@ -1,7 +1,7 @@
 import { ExecutorContext } from '@nx/devkit';
 
 import { DeployExecutorOptions } from './schema';
-import * as path from 'path';
+import * as path from 'node:path';
 
 export default async function deploy(
   engine: {

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
@@ -41,9 +41,8 @@ function formatAlreadyExistsMessage(
   packageInfo: PackageInfo,
   registry?: string
 ): string {
-  return `Package ${packageInfo.name}@${
-    packageInfo.version
-  } already exists in registry${registry ? ` ${registry}` : ''}.`;
+  const registrySuffix = registry ? ` ${registry}` : '';
+  return `Package ${packageInfo.name}@${packageInfo.version} already exists in registry${registrySuffix}.`;
 }
 
 function formatAlreadyExistsSkipMessage(packageInfo: PackageInfo): string {

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
@@ -1,9 +1,12 @@
 import { logger } from '@nx/devkit';
 import * as fileUtils from '../../../utils';
-import * as path from 'path';
+import * as path from 'node:path';
 
 import { setPackageVersion, NpmPublishOptions, spawnAsync } from '../utils';
 import { DeployExecutorOptions } from '../schema';
+
+type PackageInfo = { name: string; version: string };
+type ExistingPackagePolicy = 'error' | 'warning';
 
 async function checkIfPackageExists(
   packageName: string,
@@ -22,9 +25,7 @@ async function checkIfPackageExists(
   }
 }
 
-async function getPackageInfo(
-  distFolderPath: string
-): Promise<{ name: string; version: string }> {
+async function getPackageInfo(distFolderPath: string): Promise<PackageInfo> {
   const packageContent = await fileUtils.readFileAsync(
     path.join(distFolderPath, 'package.json'),
     { encoding: 'utf8' }
@@ -36,65 +37,116 @@ async function getPackageInfo(
   };
 }
 
+function formatAlreadyExistsMessage(
+  packageInfo: PackageInfo,
+  registry?: string
+): string {
+  return `Package ${packageInfo.name}@${
+    packageInfo.version
+  } already exists in registry${registry ? ` ${registry}` : ''}.`;
+}
+
+function formatAlreadyExistsSkipMessage(packageInfo: PackageInfo): string {
+  return `Package ${packageInfo.name}@${packageInfo.version} already exists in registry. Skipping  publish.`;
+}
+
+const whenPackageExists: Record<
+  ExistingPackagePolicy,
+  (packageInfo: PackageInfo, registry?: string) => void
+> = {
+  error: (packageInfo, registry) => {
+    throw new Error(formatAlreadyExistsMessage(packageInfo, registry));
+  },
+  warning: packageInfo => {
+    logger.warn(formatAlreadyExistsSkipMessage(packageInfo));
+  },
+};
+
+function isCheckExistingEnabled(
+  checkExisting: DeployExecutorOptions['checkExisting']
+): checkExisting is ExistingPackagePolicy {
+  return !!checkExisting && ['error', 'warning'].includes(checkExisting);
+}
+
+function logDryRunBanner(options: DeployExecutorOptions): void {
+  if (options.dryRun) {
+    logger.info('Dry-run: The package is not going to be published');
+  }
+}
+
+async function applyPackageVersionIfNeeded(
+  distFolderPath: string,
+  options: DeployExecutorOptions
+): Promise<void> {
+  /*
+  Modifying the dist when the user is dry-run mode,
+  thanks to the Nx Cache could lead to leading to publishing and unexpected package version
+  when the option is removed
+  */
+  if (options.packageVersion && !options.dryRun) {
+    await setPackageVersion(distFolderPath, options.packageVersion);
+  }
+}
+
+async function ensurePublishAllowed(
+  distFolderPath: string,
+  options: DeployExecutorOptions,
+  npmOptions: NpmPublishOptions
+): Promise<boolean> {
+  if (!isCheckExistingEnabled(options.checkExisting)) {
+    return true;
+  }
+
+  const packageInfo = await getPackageInfo(distFolderPath);
+  const exists = await checkIfPackageExists(
+    packageInfo.name,
+    packageInfo.version,
+    npmOptions
+  );
+
+  if (!exists) {
+    return true;
+  }
+
+  whenPackageExists[options.checkExisting](packageInfo, options.registry);
+
+  return false;
+}
+
+async function publishPackage(
+  distFolderPath: string,
+  npmOptions: NpmPublishOptions
+): Promise<void> {
+  await spawnAsync('npm', [
+    'publish',
+    distFolderPath,
+    ...getOptionsStringArr(npmOptions),
+  ]);
+}
+
+function logDryRunFooter(options: DeployExecutorOptions): void {
+  if (options.dryRun) {
+    logger.info('The options are:');
+    logger.info(JSON.stringify(options, null, 1));
+  }
+}
+
 export async function run(
   distFolderPath: string,
   options: DeployExecutorOptions
 ) {
   try {
-    if (options.dryRun) {
-      logger.info('Dry-run: The package is not going to be published');
-    }
-
-    /*
-    Modifying the dist when the user is dry-run mode,
-    thanks to the Nx Cache could lead to leading to publishing and unexpected package version
-    when the option is removed
-    */
-    if (options.packageVersion && !options.dryRun) {
-      await setPackageVersion(distFolderPath, options.packageVersion);
-    }
+    logDryRunBanner(options);
+    await applyPackageVersionIfNeeded(distFolderPath, options);
 
     const npmOptions = extractOnlyNPMOptions(options);
 
-    // Only check for existing package if explicitly enabled
-    if (
-      options.checkExisting &&
-      ['error', 'warning'].includes(options.checkExisting)
-    ) {
-      const packageInfo = await getPackageInfo(distFolderPath);
-      const exists = await checkIfPackageExists(
-        packageInfo.name,
-        packageInfo.version,
-        npmOptions
-      );
-
-      if (exists) {
-        if (options.checkExisting === 'error') {
-          const message = `Package ${packageInfo.name}@${
-            packageInfo.version
-          } already exists in registry${
-            options.registry ? ` ${options.registry}` : ''
-          }.`;
-          throw new Error(message);
-        } else {
-          logger.warn(
-            `Package ${packageInfo.name}@${packageInfo.version} already exists in registry. Skipping  publish.`
-          );
-          return;
-        }
-      }
+    if (!(await ensurePublishAllowed(distFolderPath, options, npmOptions))) {
+      return;
     }
 
-    await spawnAsync('npm', [
-      'publish',
-      distFolderPath,
-      ...getOptionsStringArr(npmOptions),
-    ]);
-
-    if (options.dryRun) {
-      logger.info('The options are:');
-      logger.info(JSON.stringify(options, null, 1));
-    }
+    await publishPackage(distFolderPath, npmOptions);
+    logDryRunFooter(options);
 
     logger.info(
       '🚀 Successfully published via ngx-deploy-npm! Have a nice day!'
@@ -126,6 +178,10 @@ function extractOnlyNPMOptions({
   };
 }
 
+function toKebabCase(str: string) {
+  return str.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
+}
+
 function getOptionsStringArr(options: NpmPublishOptions): string[] {
   return (
     Object.keys(options)
@@ -142,8 +198,4 @@ function getOptionsStringArr(options: NpmPublishOptions): string[] {
         cmdOptionValue.value.toString(),
       ])
   );
-
-  function toKebabCase(str: string) {
-    return str.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
-  }
 }

--- a/packages/ngx-deploy-npm/src/executors/deploy/utils/set-package-version.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/utils/set-package-version.ts
@@ -1,5 +1,5 @@
 import * as fileUtils from '../../../utils';
-import * as path from 'path';
+import * as path from 'node:path';
 
 export async function setPackageVersion(dir: string, packageVersion: string) {
   const packageContent: string = await fileUtils.readFileAsync(

--- a/packages/ngx-deploy-npm/src/executors/deploy/utils/spawn-async.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/utils/spawn-async.ts
@@ -1,5 +1,5 @@
 import { logger } from '@nx/devkit';
-import { spawn } from 'child_process';
+import { spawn } from 'node:child_process';
 
 export function spawnAsync(
   mainProgram: string,

--- a/packages/ngx-deploy-npm/src/migrations/8.0.0/replace-buildtarget-for-depends-on.ts
+++ b/packages/ngx-deploy-npm/src/migrations/8.0.0/replace-buildtarget-for-depends-on.ts
@@ -30,6 +30,25 @@ export type RemovedDeployExecutorOptions = {
 export type DeprecatedDeployExecutorOptions = DeployExecutorOptions &
   RemovedDeployExecutorOptions;
 
+function targetRequiresMigrationCreationDependsOn(
+  target: TargetConfiguration<DeprecatedDeployExecutorOptions>
+) {
+  return (
+    target.executor === 'ngx-deploy-npm:deploy' && // has the right executor
+    target.options?.noBuild !== true // the target will build the library
+  );
+}
+
+function targetRequiresMigration(
+  target: TargetConfiguration<DeprecatedDeployExecutorOptions>
+) {
+  return (
+    target.executor === 'ngx-deploy-npm:deploy' && // has the right executor
+    (target.options?.noBuild !== undefined || // the target will build the library
+      target?.options?.buildTarget !== undefined) // the target has the buildTarget option
+  );
+}
+
 export default async function update(host: Tree) {
   dependsOnMigration(host);
   removeDeprecatedOptionsMigration(host);
@@ -53,15 +72,6 @@ function dependsOnMigration(host: Tree) {
     createDependsOn(projectKey, project);
     updateProjectConfiguration(host, projectKey, project);
   });
-
-  function targetRequiresMigrationCreationDependsOn(
-    target: TargetConfiguration<DeprecatedDeployExecutorOptions>
-  ) {
-    return (
-      target.executor === 'ngx-deploy-npm:deploy' && // has the right executor
-      target.options?.noBuild !== true // the target will build the library
-    );
-  }
 
   function createDependsOn(projectKey: string, project: ProjectConfiguration) {
     const deployExecutors: [
@@ -121,16 +131,6 @@ async function removeDeprecatedOptionsMigration(host: Tree) {
     removeBuildTargetAndNoBuildOptions(project);
     updateProjectConfiguration(host, projectKey, project);
   });
-
-  function targetRequiresMigration(
-    target: TargetConfiguration<DeprecatedDeployExecutorOptions>
-  ) {
-    return (
-      target.executor === 'ngx-deploy-npm:deploy' && // has the right executor
-      (target.options?.noBuild !== undefined || // the target will build the library
-        target?.options?.buildTarget !== undefined) // the target has the buildTarget option
-    );
-  }
 
   function removeBuildTargetAndNoBuildOptions(project: ProjectConfiguration) {
     const deployExecutors: [

--- a/packages/ngx-deploy-npm/src/migrations/8.0.0/replace-buildtarget-for-depends-on.ts
+++ b/packages/ngx-deploy-npm/src/migrations/8.0.0/replace-buildtarget-for-depends-on.ts
@@ -49,6 +49,62 @@ function targetRequiresMigration(
   );
 }
 
+function createDependsOn(projectKey: string, project: ProjectConfiguration) {
+  const deployExecutors: [
+    string,
+    TargetConfiguration<DeprecatedDeployExecutorOptions>
+  ][] = Object.entries(project.targets ?? {}).filter(
+    ([targetName, targetConfig]) =>
+      targetRequiresMigrationCreationDependsOn(targetConfig)
+  );
+
+  deployExecutors.forEach(([targetName, targetConfig]) => {
+    // store the old buildTarget value
+    const buildTarget = targetConfig.options?.buildTarget;
+
+    // Create targets in case that they doesn't already exists
+    if (!project.targets) {
+      project.targets = {};
+    }
+
+    // If our executor was building the library, it needs to depend on the build target
+    let newDependsOn = 'build';
+    if (typeof buildTarget === 'string') {
+      const newPreDeployTargetName = `pre-${targetName}-build-${buildTarget}`;
+      newDependsOn = newPreDeployTargetName;
+
+      project.targets[newPreDeployTargetName] = {
+        executor: 'nx:run-commands',
+        options: {
+          command: `nx run ${projectKey}:build:${buildTarget}`,
+        },
+      };
+    }
+
+    const dependsOn = project.targets[targetName].dependsOn;
+    if (dependsOn === undefined) {
+      project.targets[targetName].dependsOn = [];
+    }
+
+    project.targets[targetName].dependsOn?.push(newDependsOn);
+  });
+}
+
+function removeBuildTargetAndNoBuildOptions(project: ProjectConfiguration) {
+  const deployExecutors: [
+    string,
+    TargetConfiguration<DeprecatedDeployExecutorOptions>
+  ][] = Object.entries(project.targets ?? {}).filter(([_, targetConfig]) =>
+    targetRequiresMigration(targetConfig)
+  );
+
+  deployExecutors.forEach(([_, targetConfig]) => {
+    // Remove option build target
+    delete targetConfig.options?.buildTarget;
+    delete targetConfig.options?.noBuild;
+  });
+}
+
 export default async function update(host: Tree) {
   dependsOnMigration(host);
   removeDeprecatedOptionsMigration(host);
@@ -72,47 +128,6 @@ function dependsOnMigration(host: Tree) {
     createDependsOn(projectKey, project);
     updateProjectConfiguration(host, projectKey, project);
   });
-
-  function createDependsOn(projectKey: string, project: ProjectConfiguration) {
-    const deployExecutors: [
-      string,
-      TargetConfiguration<DeprecatedDeployExecutorOptions>
-    ][] = Object.entries(project.targets ?? {}).filter(
-      ([targetName, targetConfig]) =>
-        targetRequiresMigrationCreationDependsOn(targetConfig)
-    );
-
-    deployExecutors.forEach(([targetName, targetConfig]) => {
-      // store the old buildTarget value
-      const buildTarget = targetConfig.options?.buildTarget;
-
-      // Create targets in case that they doesn't already exists
-      if (!project.targets) {
-        project.targets = {};
-      }
-
-      // If our executor was building the library, it needs to depend on the build target
-      let newDependsOn = 'build';
-      if (typeof buildTarget === 'string') {
-        const newPreDeployTargetName = `pre-${targetName}-build-${buildTarget}`;
-        newDependsOn = newPreDeployTargetName;
-
-        project.targets[newPreDeployTargetName] = {
-          executor: 'nx:run-commands',
-          options: {
-            command: `nx run ${projectKey}:build:${buildTarget}`,
-          },
-        };
-      }
-
-      const dependsOn = project.targets[targetName].dependsOn;
-      if (dependsOn === undefined) {
-        project.targets[targetName].dependsOn = [];
-      }
-
-      project.targets[targetName].dependsOn?.push(newDependsOn);
-    });
-  }
 }
 
 async function removeDeprecatedOptionsMigration(host: Tree) {
@@ -131,19 +146,4 @@ async function removeDeprecatedOptionsMigration(host: Tree) {
     removeBuildTargetAndNoBuildOptions(project);
     updateProjectConfiguration(host, projectKey, project);
   });
-
-  function removeBuildTargetAndNoBuildOptions(project: ProjectConfiguration) {
-    const deployExecutors: [
-      string,
-      TargetConfiguration<DeprecatedDeployExecutorOptions>
-    ][] = Object.entries(project.targets ?? {}).filter(([_, targetConfig]) =>
-      targetRequiresMigration(targetConfig)
-    );
-
-    deployExecutors.forEach(([_, targetConfig]) => {
-      // Remove option build target
-      delete targetConfig.options?.buildTarget;
-      delete targetConfig.options?.noBuild;
-    });
-  }
 }

--- a/packages/ngx-deploy-npm/src/utils/file-utils.ts
+++ b/packages/ngx-deploy-npm/src/utils/file-utils.ts
@@ -1,5 +1,5 @@
-import { promisify } from 'util';
-import { readFile, writeFile, access } from 'fs';
+import { promisify } from 'node:util';
+import { readFile, writeFile, access } from 'node:fs';
 
 export const readFileAsync = promisify(readFile);
 

--- a/packages/ngx-deploy-npm/src/utils/is-a-lib.ts
+++ b/packages/ngx-deploy-npm/src/utils/is-a-lib.ts
@@ -1,6 +1,6 @@
 import { ProjectConfiguration, readJson, Tree } from '@nx/devkit';
 import { fileExists } from './file-utils';
-import * as path from 'path';
+import * as path from 'node:path';
 
 export const isProjectAPublishableLib = async (
   tree: Tree,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

SonarCloud reports 11 open code smells on `packages/ngx-deploy-npm`: cognitive complexity in `engine.run()` (S3776), nested functions recreated on each call (S7721), and built-in imports not using the `node:` protocol (S7772).

Issue Number: N/A

## What is the new behavior?

- Refactors `engine.run()` into a linear publish pipeline with extracted helpers and a strategy map for `checkExisting` (`error` / `warning`), bringing cognitive complexity under the Sonar limit without changing runtime behavior.
- Hoists `toKebabCase` and migration predicate helpers to module scope (S7721).
- Switches production imports to `node:path`, `node:fs`, `node:util`, and `node:child_process` (S7772).

Existing unit tests (`engine.spec.ts`, migration specs) pass unchanged.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

SonarCloud project: https://sonarcloud.io/project/issues?issueStatuses=OPEN&id=bikecoders_ngx-deploy-npm

Expected outcome after analysis: 0 open issues for the rules addressed in this PR.