### PR TITLE
test(ngx-deploy-npm): adopt SIFERS pattern across unit tests

### DIFF
--- a/.cursor/rules/tests-sifers.mdc
+++ b/.cursor/rules/tests-sifers.mdc
@@ -1,0 +1,81 @@
+---
+description: "REQUIRED when writing/editing tests: SIFERS setup functions — NEVER jest.spyOn inside it() blocks"
+globs: "**/*.spec.ts,**/*.smoke.spec.ts"
+alwaysApply: true
+---
+
+# SIFERS tests — mandatory for spec files
+
+When you **create or edit** any `*.spec.ts` / `*.smoke.spec.ts` in this repo, follow **SIFERS** (**S**imple **I**njectable **F**unctions **E**xplicitly **R**eturning **S**tate).
+
+## Hard rules (violations are bugs — fix before finishing)
+
+1. **First statement in every `it` / `test` is a setup call** — destructure everything you need from it.
+2. **NEVER put `jest.spyOn`, `jest.fn`, or mock wiring inside `it` / `test`** — only inside `setup` / `setupXxx` functions.
+3. **NEVER use `beforeEach` + outer `let` for per-test state** — call `setup(opts = {})` at the top of each test instead.
+4. **Setup MUST return every spy/mock the test asserts on** — e.g. `loggerWarnSpy`, `loggerErrorSpy`, `spawnAsync` mock handles.
+5. **If an option triggers logging, setup creates the spy** — e.g. `projectGraphError` → return `loggerErrorSpy` from setup (see `generator.spec.ts`).
+6. **Nest setups per `describe`** — inner `setupVersionCheck()` calls outer `setup()` and extends state; forward unknown options.
+7. **Only refactor tests you touch** — don't rewrite unrelated tests in the same file unless asked.
+
+## Setup template (copy this shape)
+
+```typescript
+type SetupOptions = {
+  projectGraphError?: Error;
+  checkExisting?: 'warning' | 'error';
+};
+
+function setup(opts: SetupOptions = {}) {
+  const { projectGraphError, checkExisting = undefined as 'warning' | 'error' | undefined } = opts;
+
+  jest.spyOn(spawn, 'spawnAsync').mockImplementation(() => Promise.resolve());
+
+  const loggerErrorSpy = projectGraphError
+    ? jest.spyOn(logger, 'error').mockImplementation(() => undefined)
+    : undefined;
+
+  const loggerWarnSpy =
+    checkExisting === 'warning'
+      ? jest.spyOn(logger, 'warn').mockImplementation(() => undefined)
+      : undefined;
+
+  return { tree, options, loggerErrorSpy, loggerWarnSpy };
+}
+
+it('warns when package exists', async () => {
+  const { tree, options, loggerWarnSpy } = setup({ checkExisting: 'warning' });
+
+  await runMigration(tree, options);
+
+  expect(loggerWarnSpy).toHaveBeenCalledWith(expect.stringContaining('already exists'));
+});
+```
+
+## Anti-patterns — do NOT write these
+
+```typescript
+// BAD: spy inside it()
+it('warns', async () => {
+  const loggerWarnSpy = jest.spyOn(logger, 'warn'); // ← FORBIDDEN
+  const { tree } = setup();
+});
+
+// BAD: beforeEach + mutable outer state
+let tree: Tree;
+beforeEach(() => { tree = setup().tree; });
+
+// BAD: mock helper called from it() alongside setup
+it('lists', async () => {
+  const { handler } = setupHandler();
+  mockDb([row]); // ← belongs inside setupHandler via options
+});
+```
+
+## Checklist before merging test PRs
+
+- [ ] Each test begins with a **single** setup call that returns **all** mutable collaborators the test uses.
+- [ ] No test relies on another test having run or on a previous `it` having left spies configured.
+- [ ] New scenarios add **options** to setup rather than new global hooks, when possible.
+- [ ] No `jest.spyOn()` or mock creation happens inside `it()` blocks — all spies come from setup.
+- [ ] No fragmented helper functions outside setup — all mock wiring is inside setup.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,3 +22,12 @@
 - The `nx-generate` skill handles generator discovery internally - don't call nx_docs just to look up generator syntax
 
 <!-- nx configuration end-->
+
+## Tests (SIFERS — mandatory)
+
+When creating or editing `*.spec.ts` / `*.smoke.spec.ts` files, follow `.cursor/rules/tests-sifers.mdc`:
+
+- Every test starts with one `setup()` call; setup returns all mocks/spies.
+- **Never** `jest.spyOn` / mock wiring inside `it()` or `test()` blocks.
+- **Never** `beforeEach` + outer `let` for per-test state.
+- Copy patterns from `engine.spec.ts`, `generator.spec.ts`, or `write-dist-folder-path-on-deploy-target-options.spec.ts`.

--- a/packages/ngx-deploy-npm/src/executors/deploy/actions.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/actions.spec.ts
@@ -6,7 +6,14 @@ import { mockProjectRoot } from '../../__mocks__/mocks';
 import { DeployExecutorOptions } from './schema';
 
 describe('Deploy', () => {
-  const setup = () => {
+  function setup(
+    opts: {
+      distFolderPath?: string;
+      access?: DeployExecutorOptions['access'];
+    } = {}
+  ) {
+    const { distFolderPath = 'dist/libs/project', access = 'public' } = opts;
+
     const PROJECT = 'RANDOM-PROJECT';
     const mockEngine = {
       run: jest.fn().mockImplementation(() => () => Promise.resolve()),
@@ -21,19 +28,25 @@ describe('Deploy', () => {
       projectGraph: {},
     } as nxDevKit.ExecutorContext;
 
+    const options: DeployExecutorOptions = {
+      distFolderPath,
+      access,
+    };
+
     return {
       PROJECT,
       context,
       mockEngine,
+      options,
     };
-  };
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
 
   it('should invoke the engine', async () => {
-    const { mockEngine, context } = setup();
-    const options: DeployExecutorOptions = {
-      distFolderPath: 'dist/libs/project',
-      access: 'public',
-    };
+    const { mockEngine, context, options } = setup();
 
     await deploy(mockEngine, context, options);
 

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
@@ -1,3 +1,4 @@
+import { logger } from '@nx/devkit';
 import { DeployExecutorOptions } from '../schema';
 import { npmAccess } from '../../../core';
 import * as engine from './engine';
@@ -18,12 +19,8 @@ describe('engine', () => {
     Object.freeze({
       access: npmAccess.public,
     });
-  const setup = ({
-    options = defaultOption,
-    rootProject = mockProjectRoot,
-    distFolderPath = mockProjectDist(),
-    spawnAsyncMock = () => Promise.resolve(),
-  }: {
+
+  type SetupOptions = {
     rootProject?: string;
     distFolderPath?: string;
     spawnAsyncMock?: (
@@ -31,7 +28,14 @@ describe('engine', () => {
       programArgs?: string[]
     ) => Promise<void>;
     options?: Omit<DeployExecutorOptions, 'distFolderPath'>;
-  }) => {
+  };
+
+  const setup = ({
+    options = defaultOption,
+    rootProject = mockProjectRoot,
+    distFolderPath = mockProjectDist(),
+    spawnAsyncMock = () => Promise.resolve(),
+  }: SetupOptions = {}) => {
     const fullOptions: DeployExecutorOptions = {
       ...options,
       distFolderPath,
@@ -98,7 +102,7 @@ describe('engine', () => {
     }: {
       version?: string;
       setPackageReturnValue?: Promise<void>;
-    } & Parameters<typeof setup>[0]) => {
+    } & SetupOptions) => {
       jest
         .spyOn(setPackage, 'setPackageVersion')
         .mockImplementation(() => setPackageReturnValue);
@@ -157,14 +161,18 @@ describe('engine', () => {
       npmViewResult?: () => Promise<void>;
       npmPublishResult?: () => Promise<void>;
       defaultSpawnMock?: () => Promise<void>;
-    } & Omit<Parameters<typeof setup>[0], 'spawnAsyncMock'>) => {
+    } & Omit<SetupOptions, 'spawnAsyncMock'>) => {
       jest
         .spyOn(fileUtils, 'readFileAsync')
         .mockImplementation(() =>
           Promise.resolve(JSON.stringify(mockPackageJson))
         );
 
-      const spawnAsyncMock: Parameters<typeof setup>[0]['spawnAsyncMock'] = (
+      const loggerWarnSpy = jest
+        .spyOn(logger, 'warn')
+        .mockImplementation(() => undefined);
+
+      const spawnAsyncMock: SetupOptions['spawnAsyncMock'] = (
         _: string,
         args?: string[]
       ): Promise<void> => {
@@ -177,6 +185,7 @@ describe('engine', () => {
 
       return {
         mockPackageJson,
+        loggerWarnSpy,
         ...setup({
           ...originalSetupOptions,
           spawnAsyncMock,
@@ -272,6 +281,97 @@ describe('engine', () => {
         '--access',
         'public',
       ]);
+    });
+
+    it('should pass registry to npm view when checking existing package', async () => {
+      const registry = 'http://localhost:4873';
+      const { absoluteDistFolderPath, options, mockPackageJson } =
+        versionCheckSetup({
+          options: {
+            ...defaultOption,
+            checkExisting: 'warning',
+            registry,
+          },
+        });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(spawn.spawnAsync).toHaveBeenCalledWith('npm', [
+        'view',
+        `${mockPackageJson.name}@${mockPackageJson.version}`,
+        'version',
+        '--registry',
+        registry,
+      ]);
+    });
+
+    it('should log a warning when package exists and checkExisting is warning', async () => {
+      const { absoluteDistFolderPath, options, loggerWarnSpy } =
+        versionCheckSetup({
+          options: {
+            ...defaultOption,
+            checkExisting: 'warning',
+          },
+        });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining(
+          'already exists in registry. Skipping  publish.'
+        )
+      );
+    });
+  });
+
+  describe('Dry run', () => {
+    function setupDryRun(opts: { dryRun?: boolean } = {}) {
+      const { dryRun = true } = opts;
+      const loggerInfoSpy = jest
+        .spyOn(logger, 'info')
+        .mockImplementation(() => undefined);
+
+      return {
+        loggerInfoSpy,
+        ...setup({
+          options: {
+            ...defaultOption,
+            dryRun,
+          },
+        }),
+      };
+    }
+
+    it('should log dry-run banner and options when dryRun is enabled', async () => {
+      const { absoluteDistFolderPath, options, loggerInfoSpy } = setupDryRun();
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(loggerInfoSpy).toHaveBeenCalledWith(
+        'Dry-run: The package is not going to be published'
+      );
+      expect(loggerInfoSpy).toHaveBeenCalledWith('The options are:');
+    });
+  });
+
+  describe('Successful publish', () => {
+    function setupSuccessfulPublish(opts: SetupOptions = {}) {
+      const loggerInfoSpy = jest
+        .spyOn(logger, 'info')
+        .mockImplementation(() => undefined);
+
+      return { loggerInfoSpy, ...setup(opts) };
+    }
+
+    it('should log success message on successful publish', async () => {
+      const { absoluteDistFolderPath, options, loggerInfoSpy } =
+        setupSuccessfulPublish();
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(loggerInfoSpy).toHaveBeenCalledWith(
+        '🚀 Successfully published via ngx-deploy-npm! Have a nice day!'
+      );
     });
   });
 });

--- a/packages/ngx-deploy-npm/src/executors/deploy/executor.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/executor.spec.ts
@@ -1,0 +1,78 @@
+import { ExecutorContext, logger } from '@nx/devkit';
+
+import runExecutor from './executor';
+import deploy from './actions';
+import { mockProjectRoot } from '../../__mocks__/mocks';
+import { DeployExecutorOptions } from './schema';
+
+jest.mock('./actions', () => ({
+  __esModule: true,
+  default: jest.fn(),
+}));
+
+const mockedDeploy = deploy as jest.MockedFunction<typeof deploy>;
+
+describe('runExecutor', () => {
+  function setupRunExecutor(
+    opts: {
+      deployError?: Error;
+    } = {}
+  ) {
+    const { deployError } = opts;
+
+    mockedDeploy.mockReset();
+    if (deployError) {
+      mockedDeploy.mockRejectedValue(deployError);
+    } else {
+      mockedDeploy.mockResolvedValue(undefined);
+    }
+
+    const loggerErrorSpy = jest
+      .spyOn(logger, 'error')
+      .mockImplementation(() => undefined);
+
+    const context = {
+      root: mockProjectRoot,
+      projectName: 'test-project',
+    } as ExecutorContext;
+
+    const options: DeployExecutorOptions = {
+      distFolderPath: 'dist/libs/test',
+      access: 'public',
+    };
+
+    return { context, options, loggerErrorSpy };
+  }
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return success when deploy completes', async () => {
+    const { context, options } = setupRunExecutor();
+
+    const result = await runExecutor(options, context);
+
+    expect(result).toEqual({ success: true });
+    expect(mockedDeploy).toHaveBeenCalledWith(
+      expect.objectContaining({ run: expect.any(Function) }),
+      context,
+      options
+    );
+  });
+
+  it('should return failure and log errors when deploy throws', async () => {
+    const publishError = new Error('publish failed');
+    const { context, options, loggerErrorSpy } = setupRunExecutor({
+      deployError: publishError,
+    });
+
+    const result = await runExecutor(options, context);
+
+    expect(result).toEqual({ success: false });
+    expect(loggerErrorSpy).toHaveBeenCalledWith(publishError);
+    expect(loggerErrorSpy).toHaveBeenCalledWith(
+      'Error when trying to publish the library'
+    );
+  });
+});

--- a/packages/ngx-deploy-npm/src/executors/deploy/utils/set-package-version.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/utils/set-package-version.spec.ts
@@ -9,46 +9,56 @@ jest.mock('../../../utils', () => {
 });
 
 describe('setPackageVersion', () => {
-  let myPackageJSON: Record<string, unknown>;
-  let expectedPackage: Record<string, unknown>;
-  let version: string;
-  let dir: string;
+  function setupSetPackageVersion(
+    opts: {
+      version?: string;
+      dir?: string;
+      packageJson?: Record<string, unknown>;
+    } = {}
+  ) {
+    const {
+      version = '1.0.1-next0',
+      dir = 'some/random/dir',
+      packageJson = {
+        name: 'ngx-deploy-npm',
+        version: 'boilerPlate',
+        description: 'Publish your libraries to NPM with just one command',
+        main: 'index.js',
+      },
+    } = opts;
 
-  let valueWriten: Parameters<typeof fileUtils.writeFileAsync>[1];
+    const written = {
+      value: undefined as
+        | Parameters<typeof fileUtils.writeFileAsync>[1]
+        | undefined,
+    };
 
-  // Spies
-  beforeEach(() => {
     jest
       .spyOn(fileUtils, 'readFileAsync')
-      .mockImplementation(() => Promise.resolve(JSON.stringify(myPackageJSON)));
+      .mockImplementation(() => Promise.resolve(JSON.stringify(packageJson)));
 
     jest.spyOn(fileUtils, 'writeFileAsync').mockImplementation((_, data) => {
-      valueWriten = data;
+      written.value = data;
       return Promise.resolve();
     });
-  });
 
-  // Data
-  beforeEach(() => {
-    version = '1.0.1-next0';
-    dir = 'some/random/dir';
-
-    myPackageJSON = {
-      name: 'ngx-deploy-npm',
-      version: 'boilerPlate',
-      description: 'Publish your libraries to NPM with just one command',
-      main: 'index.js',
-    };
-
-    expectedPackage = {
-      ...myPackageJSON,
+    const expectedPackage = {
+      ...packageJson,
       version,
     };
+
+    return { dir, version, expectedPackage, written };
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
   });
 
   it('should write the version of the sent on the package.json', async () => {
+    const { dir, version, expectedPackage, written } = setupSetPackageVersion();
+
     await setPackageVersion(dir, version);
 
-    expect(valueWriten).toEqual(JSON.stringify(expectedPackage, null, 4));
+    expect(written.value).toEqual(JSON.stringify(expectedPackage, null, 4));
   });
 });

--- a/packages/ngx-deploy-npm/src/executors/deploy/utils/spawn-async.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/utils/spawn-async.spec.ts
@@ -3,136 +3,156 @@ import { logger } from '@nx/devkit';
 import { spawnAsync } from './spawn-async';
 import * as child_process from 'child_process';
 import type { SpawnMock } from '../../../__mocks__/child_process';
+
 jest.mock('child_process');
 const mockedChildProcess: SpawnMock = child_process as unknown as SpawnMock;
 
 describe('spawnAsync', () => {
-  setMockPlatform('linux');
+  const originalEnv = process.env;
+  const originalPlatform = process.platform;
 
-  afterAll(() => {
+  function setupSpawn(
+    opts: {
+      platform?: 'linux' | 'win32';
+      comspec?: string;
+      command?: string;
+      programArgs?: string[];
+    } = {}
+  ) {
+    const {
+      platform = 'linux',
+      comspec = 'C:\\Windows\\system\\cmd.exe',
+      command = platform === 'win32' ? 'dir' : 'ls',
+      programArgs = [],
+    } = opts;
+
+    process.env = {
+      ...originalEnv,
+      ...(platform === 'win32' ? { comspec } : {}),
+    };
+    Object.defineProperty(process, 'platform', { value: platform });
+
+    const processKey = platform === 'win32' ? comspec : command;
+    const loggerInfoMock = logger.info as jest.Mock;
+    loggerInfoMock.mockClear();
+
+    return {
+      command,
+      programArgs,
+      processKey,
+      comspec,
+      mockedChildProcess,
+      loggerInfoMock,
+    };
+  }
+
+  afterEach(() => {
+    process.env = originalEnv;
+    Object.defineProperty(process, 'platform', { value: originalPlatform });
     jest.clearAllMocks();
   });
 
   it('should complete the promise when the command finish', async () => {
-    const command = 'ls';
+    const { command, processKey, mockedChildProcess } = setupSpawn();
 
     const promise = spawnAsync(command);
-    mockedChildProcess.listOfChildProcess[command].emit('close', 0);
+    mockedChildProcess.listOfChildProcess[processKey].emit('close', 0);
     const returnedValue = await promise;
 
     expect(returnedValue).toBeUndefined();
   });
 
   it('should reject the promise when the command finish with error code', async () => {
-    const command = 'ls';
+    const { command, processKey, mockedChildProcess } = setupSpawn();
     const errorCode = 1;
 
     await expect(() => {
       const promise = spawnAsync(command);
-      mockedChildProcess.listOfChildProcess[command].emit('close', errorCode);
+      mockedChildProcess.listOfChildProcess[processKey].emit(
+        'close',
+        errorCode
+      );
 
       return promise;
     }).rejects.toEqual(errorCode);
   });
 
   it('should reject the promise when the command emits on the error event', async () => {
-    const command = 'ls';
+    const { command, processKey, mockedChildProcess } = setupSpawn();
     const errorData = 'error-data';
 
     await expect(() => {
       const promise = spawnAsync(command);
-      mockedChildProcess.listOfChildProcess[command].emit('error', errorData);
+      mockedChildProcess.listOfChildProcess[processKey].emit(
+        'error',
+        errorData
+      );
 
       return promise;
     }).rejects.toEqual(errorData);
   });
 
   it("should log the data of the command's standard output (stdout)", async () => {
-    const command = 'ls';
+    const { command, processKey, mockedChildProcess, loggerInfoMock } =
+      setupSpawn();
     const buffer = Buffer.from('buffer with data');
 
     const promise = spawnAsync(command);
-    mockedChildProcess.listOfChildProcess[command].stdout.emit('data', buffer);
-    mockedChildProcess.listOfChildProcess[command].emit('close', 0);
+    mockedChildProcess.listOfChildProcess[processKey].stdout.emit(
+      'data',
+      buffer
+    );
+    mockedChildProcess.listOfChildProcess[processKey].emit('close', 0);
     await promise;
 
-    expect(logger.info).toHaveBeenCalledWith(buffer.toString());
+    expect(loggerInfoMock).toHaveBeenCalledWith(buffer.toString());
   });
 
   it("should log the data of the command's standard error (stderr)", async () => {
-    const command = 'ls';
+    const { command, processKey, mockedChildProcess, loggerInfoMock } =
+      setupSpawn();
     const buffer = Buffer.from('buffer with data');
 
     const promise = spawnAsync(command);
-    mockedChildProcess.listOfChildProcess[command].stderr.emit('data', buffer);
-    mockedChildProcess.listOfChildProcess[command].emit('close', 0);
+    mockedChildProcess.listOfChildProcess[processKey].stderr.emit(
+      'data',
+      buffer
+    );
+    mockedChildProcess.listOfChildProcess[processKey].emit('close', 0);
     await promise;
 
-    expect(logger.info).toHaveBeenCalledWith(buffer.toString());
+    expect(loggerInfoMock).toHaveBeenCalledWith(buffer.toString());
   });
 
   describe('Windows OS', () => {
-    setMockPlatform('win32', {
-      comspec: 'C:\\Windows\\system\\cmd.exe',
-    });
-
     it('should complete the promise when the command finish', async () => {
-      const command = 'dir';
+      const { command, processKey, mockedChildProcess } = setupSpawn({
+        platform: 'win32',
+      });
 
       const promise = spawnAsync(command);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      mockedChildProcess.listOfChildProcess[process.env.comspec!].emit(
-        'close',
-        0
-      );
+      mockedChildProcess.listOfChildProcess[processKey].emit('close', 0);
       const returnedValue = await promise;
 
       expect(returnedValue).toBeUndefined();
     });
 
     it('should have called original spawn with the right attributes', async () => {
-      const command = 'dir';
-      const commandParams = ['/w'];
+      const { command, programArgs, processKey, comspec, mockedChildProcess } =
+        setupSpawn({
+          platform: 'win32',
+          programArgs: ['/w'],
+        });
 
-      const promise = spawnAsync(command, commandParams);
-      // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-      mockedChildProcess.listOfChildProcess[process.env.comspec!].emit(
-        'close',
-        0
-      );
+      const promise = spawnAsync(command, programArgs);
+      mockedChildProcess.listOfChildProcess[processKey].emit('close', 0);
       await promise;
 
-      expect(mockedChildProcess.spawn).toHaveBeenCalledWith(
-        process.env.comspec,
-        ['/c', command, ...commandParams]
-      );
+      expect(mockedChildProcess.spawn).toHaveBeenCalledWith(comspec, [
+        '/c',
+        command,
+        ...programArgs,
+      ]);
     });
   });
 });
-
-function setMockPlatform(
-  mockPlatform: typeof process.platform,
-  environmentVar?: Record<string, string>
-) {
-  const originalEnv = process.env;
-  const originalPlatform = process.platform;
-
-  beforeEach(() => {
-    jest.resetModules();
-    process.env = {
-      ...originalEnv,
-      ...(environmentVar ? environmentVar : {}),
-    };
-
-    Object.defineProperty(process, 'platform', {
-      value: mockPlatform,
-    });
-  });
-
-  afterEach(() => {
-    process.env = originalEnv;
-    Object.defineProperty(process, 'platform', {
-      value: originalPlatform,
-    });
-  });
-}

--- a/packages/ngx-deploy-npm/src/generators/install/generator.spec.ts
+++ b/packages/ngx-deploy-npm/src/generators/install/generator.spec.ts
@@ -6,6 +6,7 @@ import {
   TargetConfiguration,
   createProjectGraphAsync,
   ProjectGraph,
+  logger,
 } from '@nx/devkit';
 
 import generator from './generator';
@@ -55,10 +56,14 @@ describe('install generator', () => {
 
         return acc;
       }, {} as Record<string, true>),
+    projectGraphError,
+    projectGraphExclude = [],
   }: {
     workspaceProjects?: Record<string, ProjectConfiguration>;
     workspacePublishableLibs?: Record<string, true>;
-  }) => {
+    projectGraphError?: Error;
+    projectGraphExclude?: string[];
+  } = {}) => {
     const workspaceConfig = new Map();
     const appTree = createTreeWithEmptyWorkspace();
 
@@ -82,8 +87,13 @@ describe('install generator', () => {
         typeof createProjectGraphAsync
       >
     ).mockImplementation(async () => {
-      const nodes = Object.entries(workspaceProjects).reduce(
-        (acc, [projectName, projectConfig]) => {
+      if (projectGraphError) {
+        throw projectGraphError;
+      }
+
+      const nodes = Object.entries(workspaceProjects)
+        .filter(([projectName]) => !projectGraphExclude.includes(projectName))
+        .reduce((acc, [projectName, projectConfig]) => {
           acc[projectName] = {
             name: projectName,
             type: 'lib',
@@ -94,9 +104,7 @@ describe('install generator', () => {
             },
           };
           return acc;
-        },
-        {} as ProjectGraph['nodes']
-      );
+        }, {} as ProjectGraph['nodes']);
 
       return {
         nodes,
@@ -104,12 +112,16 @@ describe('install generator', () => {
       };
     });
 
+    const loggerErrorSpy = projectGraphError
+      ? jest.spyOn(logger, 'error').mockImplementation(() => undefined)
+      : undefined;
+
     // Create workspace
     Array.from(workspaceConfig.entries()).forEach(([key, projectConfig]) =>
       addProjectConfiguration(appTree, key, projectConfig)
     );
 
-    return { appTree };
+    return { appTree, loggerErrorSpy };
   };
 
   const buildMockDistPath = (projectName: string) => {
@@ -283,6 +295,55 @@ describe('install generator', () => {
         project?.targets?.deploy.options;
 
       expect(targetOptions.access).toEqual(npmAccess.restricted);
+    });
+  });
+
+  describe('build target detection', () => {
+    it('should not add dependsOn when project is missing from project graph', async () => {
+      const projectName = 'graphMissingLib';
+      const { appTree } = setup({
+        workspaceProjects: {
+          [projectName]: mocks.getLib(projectName),
+        },
+        workspacePublishableLibs: { [projectName]: true },
+        projectGraphExclude: [projectName],
+      });
+
+      await generator(appTree, {
+        project: projectName,
+        distFolderPath: buildMockDistPath(projectName),
+        access: npmAccess.public,
+      });
+
+      const targetDeploy =
+        getProjects(appTree).get(projectName)?.targets?.deploy;
+
+      expect(targetDeploy?.dependsOn).toBeUndefined();
+    });
+
+    it('should not add dependsOn and log error when project graph fails', async () => {
+      const projectName = 'graphErrorLib';
+      const { appTree, loggerErrorSpy } = setup({
+        workspaceProjects: {
+          [projectName]: mocks.getLib(projectName),
+        },
+        workspacePublishableLibs: { [projectName]: true },
+        projectGraphError: new Error('graph error'),
+      });
+
+      await generator(appTree, {
+        project: projectName,
+        distFolderPath: buildMockDistPath(projectName),
+        access: npmAccess.public,
+      });
+
+      const targetDeploy =
+        getProjects(appTree).get(projectName)?.targets?.deploy;
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith(
+        expect.stringContaining('Error detecting build target')
+      );
+      expect(targetDeploy?.dependsOn).toBeUndefined();
     });
   });
 

--- a/packages/ngx-deploy-npm/src/migrations/8.0.0/replace-buildtarget-for-depends-on.spec.ts
+++ b/packages/ngx-deploy-npm/src/migrations/8.0.0/replace-buildtarget-for-depends-on.spec.ts
@@ -16,11 +16,30 @@ import update, {
 } from './replace-buildtarget-for-depends-on';
 import { DeployExecutorOptions } from '../../executors/deploy/schema';
 
+type ProjectSetup = Record<
+  string,
+  {
+    project: ProjectConfiguration;
+    config: {
+      build: {
+        buildConfigs?: string[];
+      };
+      deploy: Record<
+        string,
+        {
+          preExistedDependsOn?: (TargetDependencyConfig | string)[];
+          options?: RemovedDeployExecutorOptions;
+        }
+      >;
+    };
+  }
+>;
+
 describe('replace-configuration-param-for-depends-on migration', () => {
-  const expectedDeployTarget = (
+  function expectedDeployTarget(
     name: string,
     dependsOn: (TargetDependencyConfig | string)[] = []
-  ): TargetConfiguration<DeployExecutorOptions> => {
+  ): TargetConfiguration<DeployExecutorOptions> {
     const target: TargetConfiguration<DeployExecutorOptions> = {
       executor: 'ngx-deploy-npm:deploy',
       options: {
@@ -34,28 +53,9 @@ describe('replace-configuration-param-for-depends-on migration', () => {
     }
 
     return target;
-  };
+  }
 
-  const setUp = (
-    projects: Record<
-      string,
-      {
-        project: ProjectConfiguration;
-        config: {
-          build: {
-            buildConfigs?: string[];
-          };
-          deploy: Record<
-            string,
-            {
-              preExistedDependsOn?: (TargetDependencyConfig | string)[];
-              options?: RemovedDeployExecutorOptions;
-            }
-          >;
-        };
-      }
-    >
-  ) => {
+  function setup(projects: ProjectSetup = {}) {
     const addConfig = (
       project: ProjectConfiguration,
       config: {
@@ -71,7 +71,6 @@ describe('replace-configuration-param-for-depends-on migration', () => {
         >;
       }
     ) => {
-      // Add build configs
       if (config.build.buildConfigs && project.targets?.build) {
         project.targets.build.options = {
           ...(project.targets.build.options ?? {}),
@@ -82,7 +81,6 @@ describe('replace-configuration-param-for-depends-on migration', () => {
         };
       }
 
-      // Add deploy configs
       Object.entries(config.deploy).forEach(
         ([targetKey, { options, preExistedDependsOn }]) => {
           const deployTarget: TargetConfiguration<DeprecatedDeployExecutorOptions> =
@@ -126,10 +124,33 @@ describe('replace-configuration-param-for-depends-on migration', () => {
     );
 
     return { tree, nonMigratedProjects };
-  };
+  }
+
+  function getAllNgxDeployNPMTargets(tree: Tree) {
+    return Array.from(getProjects(tree)).reduce(
+      (acc, [projectName, project]) => {
+        const everyDeployTargets = Object.entries(project.targets ?? {})
+          .filter(([, target]) => target.executor === 'ngx-deploy-npm:deploy')
+          .map(
+            ([, targetConfig]) =>
+              targetConfig as TargetConfiguration<DeprecatedDeployExecutorOptions>
+          );
+
+        if (everyDeployTargets.length > 0) {
+          acc[projectName] = everyDeployTargets;
+        }
+
+        return acc;
+      },
+      {} as Record<
+        string,
+        TargetConfiguration<DeprecatedDeployExecutorOptions>[]
+      >
+    );
+  }
 
   it('should migrate anything', async () => {
-    const { tree } = setUp({});
+    const { tree } = setup();
 
     const allProjectsBeforeMigration = getProjects(tree);
     await update(tree);
@@ -139,33 +160,25 @@ describe('replace-configuration-param-for-depends-on migration', () => {
   });
 
   describe('Remove Deprecated Options', () => {
-    const setupRemoveDep = ({
-      deployConfig = [
-        {
-          noBuild: true,
-          buildTarget: 'staging',
-        },
-        {
-          noBuild: true,
-          buildTarget: 'production',
-        },
-        {
-          noBuild: true,
-          buildTarget: 'staging',
-        },
-        {
-          noBuild: true,
-          buildTarget: 'production',
-        },
-      ],
-    }: {
-      deployConfig?: [
-        RemovedDeployExecutorOptions,
-        RemovedDeployExecutorOptions,
-        RemovedDeployExecutorOptions,
-        RemovedDeployExecutorOptions
-      ];
-    }) => {
+    function setupRemoveDep(
+      opts: {
+        deployConfig?: [
+          RemovedDeployExecutorOptions,
+          RemovedDeployExecutorOptions,
+          RemovedDeployExecutorOptions,
+          RemovedDeployExecutorOptions
+        ];
+      } = {}
+    ) {
+      const {
+        deployConfig = [
+          { noBuild: true, buildTarget: 'staging' },
+          { noBuild: true, buildTarget: 'production' },
+          { noBuild: true, buildTarget: 'staging' },
+          { noBuild: true, buildTarget: 'production' },
+        ],
+      } = opts;
+
       const PROJECT_NAME = 'PROJECT_NAME';
       const PROJECT_NAME2 = 'PROJECT_NAME2';
 
@@ -183,7 +196,7 @@ describe('replace-configuration-param-for-depends-on migration', () => {
         },
       });
 
-      const { tree } = setUp({
+      const { tree } = setup({
         PROJECT_NAME: {
           project: mocks.getLib(PROJECT_NAME),
           config: projectConfig(),
@@ -194,7 +207,7 @@ describe('replace-configuration-param-for-depends-on migration', () => {
         },
       });
 
-      const expectedDeployTargets = () => ({
+      const expectedDeployTargets = {
         PROJECT_NAME: [
           expectedDeployTarget(PROJECT_NAME),
           expectedDeployTarget(PROJECT_NAME),
@@ -203,27 +216,10 @@ describe('replace-configuration-param-for-depends-on migration', () => {
           expectedDeployTarget(PROJECT_NAME2),
           expectedDeployTarget(PROJECT_NAME2),
         ],
-      });
+      };
 
-      return { tree, PROJECT_NAME, PROJECT_NAME2, expectedDeployTargets };
-    };
-
-    // this is not filtering the projects with the executor
-    const getAllNgxDeployNPMTargets = (tree: Tree) =>
-      Array.from(getProjects(tree)).reduce((acc, [projectName, project]) => {
-        const everyDeployTargets = Object.entries(project.targets ?? {})
-          .filter(([, target]) => target.executor === 'ngx-deploy-npm:deploy')
-          .map(
-            ([, targetConfig]) =>
-              targetConfig as TargetConfiguration<DeprecatedDeployExecutorOptions>
-          );
-
-        if (everyDeployTargets.length > 0) {
-          acc[projectName] = everyDeployTargets;
-        }
-
-        return acc;
-      }, {} as Record<string, TargetConfiguration<DeprecatedDeployExecutorOptions>[]>);
+      return { tree, expectedDeployTargets };
+    }
 
     it("should remove the `noBuild` option when it's set to `true`", async () => {
       const { tree, expectedDeployTargets } = setupRemoveDep({
@@ -236,25 +232,27 @@ describe('replace-configuration-param-for-depends-on migration', () => {
       });
 
       await update(tree);
-      const allDeployTargets = getAllNgxDeployNPMTargets(tree);
 
-      expect(allDeployTargets).toStrictEqual(expectedDeployTargets());
+      expect(getAllNgxDeployNPMTargets(tree)).toStrictEqual(
+        expectedDeployTargets
+      );
     });
 
     it('should remove if the target has `buildTarget` option and `noBuild` is set to `true`', async () => {
       const { tree, expectedDeployTargets } = setupRemoveDep({});
 
       await update(tree);
-      const allDeployTargets = getAllNgxDeployNPMTargets(tree);
 
-      expect(allDeployTargets).toStrictEqual(expectedDeployTargets());
+      expect(getAllNgxDeployNPMTargets(tree)).toStrictEqual(
+        expectedDeployTargets
+      );
     });
   });
 
   describe('Migrate Deprecated Options', () => {
     describe('`buildTarget` should be migrated to use a `dependsOn` instead', () => {
-      it('should migrate anything if `noBuild` is set to true', async () => {
-        const setupOptions: Parameters<typeof setUp>[0] = {
+      function setupNoBuildTrueMigration() {
+        const { tree } = setup({
           shouldNotBeTouchedLib: {
             project: mocks.getLib('shouldNotBeTouchedLib'),
             config: {
@@ -296,24 +294,7 @@ describe('replace-configuration-param-for-depends-on migration', () => {
               },
             },
           },
-        };
-        const { tree } = setUp(setupOptions);
-
-        await update(tree);
-        const allProjectsAfterMigration = getProjects(tree);
-
-        const allDeployTargetsAfterMigration = [];
-        allDeployTargetsAfterMigration.push(
-          allProjectsAfterMigration.get('shouldNotBeTouchedLib')?.targets?.[
-            'publishLocal'
-          ],
-          allProjectsAfterMigration.get('shouldNotBeTouchedLib')?.targets?.[
-            'publishStaging'
-          ],
-          allProjectsAfterMigration.get('shouldNotBeTouchedLib2')?.targets?.[
-            'publishLocal'
-          ]
-        );
+        });
 
         const expectedDeployTargets = [
           expectedDeployTarget('shouldNotBeTouchedLib', [
@@ -324,13 +305,11 @@ describe('replace-configuration-param-for-depends-on migration', () => {
           expectedDeployTarget('shouldNotBeTouchedLib2', ['prePublish:local']),
         ];
 
-        expect(allDeployTargetsAfterMigration).toStrictEqual(
-          expectedDeployTargets
-        );
-      });
+        return { tree, expectedDeployTargets };
+      }
 
-      it('should migration put the `dependsOn` for packages that are being built', async () => {
-        const setupOptions: Parameters<typeof setUp>[0] = {
+      function setupCreateDependsOnMigration() {
+        const { tree } = setup({
           shouldCreateDependsOn: {
             project: mocks.getLib('shouldCreateDependsOn'),
             config: {
@@ -352,26 +331,9 @@ describe('replace-configuration-param-for-depends-on migration', () => {
               },
             },
           },
-        };
-        const { tree } = setUp(setupOptions);
+        });
 
-        await update(tree);
-        const allProjectsAfterMigration = getProjects(tree);
-
-        const allTargetsAfterMigration: Record<
-          string,
-          TargetConfiguration<unknown | DeployExecutorOptions> | undefined
-        > = {
-          publishLocal: allProjectsAfterMigration.get('shouldCreateDependsOn')
-            ?.targets?.['publishLocal'],
-          publishStaging: allProjectsAfterMigration.get('shouldCreateDependsOn')
-            ?.targets?.['publishStaging'],
-        };
-
-        const expectedDeployTargets: Record<
-          string,
-          TargetConfiguration<unknown | DeployExecutorOptions> | undefined
-        > = {
+        const expectedDeployTargets = {
           publishLocal: expectedDeployTarget('shouldCreateDependsOn', [
             'existingDependsOn',
             'build',
@@ -381,11 +343,11 @@ describe('replace-configuration-param-for-depends-on migration', () => {
           ]),
         };
 
-        expect(allTargetsAfterMigration).toStrictEqual(expectedDeployTargets);
-      });
+        return { tree, expectedDeployTargets };
+      }
 
-      it('should create a pre-deploy target when the option `buildTarget` is present', async () => {
-        const setupOptions: Parameters<typeof setUp>[0] = {
+      function setupBuildTargetMigration() {
+        const { tree } = setup({
           shouldCreateDependsOn: {
             project: mocks.getLib('shouldCreateDependsOn'),
             config: {
@@ -409,32 +371,9 @@ describe('replace-configuration-param-for-depends-on migration', () => {
               },
             },
           },
-        };
-        const { tree } = setUp(setupOptions);
+        });
 
-        await update(tree);
-        const allProjectsAfterMigration = getProjects(tree);
-
-        const allTargetsAfterMigration: Record<
-          string,
-          TargetConfiguration<unknown | DeployExecutorOptions> | undefined
-        > = {
-          'pre-publishLocal-build-local': allProjectsAfterMigration.get(
-            'shouldCreateDependsOn'
-          )?.targets?.['pre-publishLocal-build-local'],
-          'pre-publishStaging-build-staging': allProjectsAfterMigration.get(
-            'shouldCreateDependsOn'
-          )?.targets?.['pre-publishStaging-build-staging'],
-          publishLocal: allProjectsAfterMigration.get('shouldCreateDependsOn')
-            ?.targets?.['publishLocal'],
-          publishStaging: allProjectsAfterMigration.get('shouldCreateDependsOn')
-            ?.targets?.['publishStaging'],
-        };
-
-        const expectedDeployTargets: Record<
-          string,
-          TargetConfiguration<unknown | DeployExecutorOptions> | undefined
-        > = {
+        const expectedDeployTargets = {
           'pre-publishLocal-build-local': {
             executor: 'nx:run-commands',
             options: {
@@ -454,6 +393,67 @@ describe('replace-configuration-param-for-depends-on migration', () => {
           publishStaging: expectedDeployTarget('shouldCreateDependsOn', [
             'pre-publishStaging-build-staging',
           ]),
+        };
+
+        return { tree, expectedDeployTargets };
+      }
+
+      it('should migrate anything if `noBuild` is set to true', async () => {
+        const { tree, expectedDeployTargets } = setupNoBuildTrueMigration();
+
+        await update(tree);
+
+        const allProjectsAfterMigration = getProjects(tree);
+        const allDeployTargetsAfterMigration = [
+          allProjectsAfterMigration.get('shouldNotBeTouchedLib')?.targets?.[
+            'publishLocal'
+          ],
+          allProjectsAfterMigration.get('shouldNotBeTouchedLib')?.targets?.[
+            'publishStaging'
+          ],
+          allProjectsAfterMigration.get('shouldNotBeTouchedLib2')?.targets?.[
+            'publishLocal'
+          ],
+        ];
+
+        expect(allDeployTargetsAfterMigration).toStrictEqual(
+          expectedDeployTargets
+        );
+      });
+
+      it('should migration put the `dependsOn` for packages that are being built', async () => {
+        const { tree, expectedDeployTargets } = setupCreateDependsOnMigration();
+
+        await update(tree);
+
+        const allProjectsAfterMigration = getProjects(tree);
+        const allTargetsAfterMigration = {
+          publishLocal: allProjectsAfterMigration.get('shouldCreateDependsOn')
+            ?.targets?.['publishLocal'],
+          publishStaging: allProjectsAfterMigration.get('shouldCreateDependsOn')
+            ?.targets?.['publishStaging'],
+        };
+
+        expect(allTargetsAfterMigration).toStrictEqual(expectedDeployTargets);
+      });
+
+      it('should create a pre-deploy target when the option `buildTarget` is present', async () => {
+        const { tree, expectedDeployTargets } = setupBuildTargetMigration();
+
+        await update(tree);
+
+        const allProjectsAfterMigration = getProjects(tree);
+        const allTargetsAfterMigration = {
+          'pre-publishLocal-build-local': allProjectsAfterMigration.get(
+            'shouldCreateDependsOn'
+          )?.targets?.['pre-publishLocal-build-local'],
+          'pre-publishStaging-build-staging': allProjectsAfterMigration.get(
+            'shouldCreateDependsOn'
+          )?.targets?.['pre-publishStaging-build-staging'],
+          publishLocal: allProjectsAfterMigration.get('shouldCreateDependsOn')
+            ?.targets?.['publishLocal'],
+          publishStaging: allProjectsAfterMigration.get('shouldCreateDependsOn')
+            ?.targets?.['publishStaging'],
         };
 
         expect(allTargetsAfterMigration).toStrictEqual(expectedDeployTargets);

--- a/packages/ngx-deploy-npm/src/migrations/8.0.0/write-dist-folder-path-on-deploy-target-options.spec.ts
+++ b/packages/ngx-deploy-npm/src/migrations/8.0.0/write-dist-folder-path-on-deploy-target-options.spec.ts
@@ -5,7 +5,9 @@ import {
   Tree,
   addProjectConfiguration,
   getProjects,
+  logger,
 } from '@nx/devkit';
+import * as devkit from '@nx/devkit';
 import * as mocks from '../../__mocks__/mocks';
 
 import update, {
@@ -13,32 +15,31 @@ import update, {
 } from './write-dist-folder-path-on-deploy-target-options';
 
 describe('write-dist-folder-path-on-deploy-target-options migration', () => {
-  const setUp = () => {
-    const addTargets = (
-      project: ProjectConfiguration,
-      addDistFolderPathOption = true
-    ) => {
-      if (!project.targets) {
-        project.targets = {};
-      }
+  function addTargets(
+    project: ProjectConfiguration,
+    addDistFolderPathOption = true
+  ): ProjectConfiguration {
+    if (!project.targets) {
+      project.targets = {};
+    }
 
-      const deployTarget: TargetConfiguration<DeprecatedDeployExecutorOptions> =
-        {
-          executor: 'ngx-deploy-npm:deploy',
-          options: {
-            distFolderPath: addDistFolderPathOption
-              ? `dist/libs/${project.name}`
-              : undefined,
-            access: 'public',
-          },
-        };
-
-      project.targets.deploy = deployTarget;
-      project.targets.publish = deployTarget;
-
-      return project;
+    const deployTarget: TargetConfiguration<DeprecatedDeployExecutorOptions> = {
+      executor: 'ngx-deploy-npm:deploy',
+      options: {
+        distFolderPath: addDistFolderPathOption
+          ? `dist/libs/${project.name}`
+          : undefined,
+        access: 'public',
+      },
     };
 
+    project.targets.deploy = deployTarget;
+    project.targets.publish = deployTarget;
+
+    return project;
+  }
+
+  function setup() {
     const nonMigratedProjects: Record<string, ProjectConfiguration> = {
       WITH_distFolderPathOption: addTargets(
         mocks.getLib('WITH_distFolderPathOption')
@@ -63,10 +64,59 @@ describe('write-dist-folder-path-on-deploy-target-options migration', () => {
     );
 
     return { tree, nonMigratedProjects };
-  };
+  }
+
+  function setupUntouchedProjectsCheck() {
+    const { tree } = setup();
+
+    const getNonMigratedProjects = (host: Tree) => {
+      const allProjects = getProjects(host);
+      return {
+        projectBefore: allProjects.get('projectBefore'),
+        WITH_distFolderPathOption: allProjects.get('WITH_distFolderPathOption'),
+        app: allProjects.get('app'),
+        nonPublishable: allProjects.get('nonPublishable'),
+      };
+    };
+
+    return {
+      tree,
+      nonMigratedProjectsBefore: getNonMigratedProjects(tree),
+      getNonMigratedProjects,
+    };
+  }
+
+  function setupUnnamedProjectWarning(opts: { projectKey?: string } = {}) {
+    const { projectKey = 'UNNAMED_PROJECT' } = opts;
+    const { tree } = setup();
+
+    const unnamedProject = addTargets(mocks.getLib(projectKey), false);
+    addProjectConfiguration(tree, projectKey, unnamedProject);
+
+    const projects = getProjects(tree);
+    const projectWithoutName = {
+      ...projects.get(projectKey)!,
+      name: undefined,
+    };
+    projects.set(projectKey, projectWithoutName);
+
+    const getProjectsSpy = jest
+      .spyOn(devkit, 'getProjects')
+      .mockReturnValue(projects);
+
+    const loggerWarnSpy = jest
+      .spyOn(logger, 'warn')
+      .mockImplementation(() => undefined);
+
+    return { tree, projectKey, getProjectsSpy, loggerWarnSpy };
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
 
   it('should set up the distFolderPath option on the right projects', async () => {
-    const { tree } = setUp();
+    const { tree } = setup();
 
     await update(tree);
 
@@ -93,7 +143,7 @@ describe('write-dist-folder-path-on-deploy-target-options migration', () => {
   });
 
   it('should set up the distFolderPath option with the right value', async () => {
-    const { tree } = setUp();
+    const { tree } = setup();
 
     await update(tree);
 
@@ -111,22 +161,23 @@ describe('write-dist-folder-path-on-deploy-target-options migration', () => {
   });
 
   it('should not touch other projects', async () => {
-    const { tree } = setUp();
-    const getNonMigratedProjects = (tree: Tree) => {
-      const allProjects = getProjects(tree);
-      return {
-        projectBefore: allProjects.get('projectBefore'),
-        WITH_distFolderPathOption: allProjects.get('WITH_distFolderPathOption'),
-        app: allProjects.get('app'),
-        nonPublishable: allProjects.get('nonPublishable'),
-      };
-    };
-    const nonMigratedProjectsBefore = getNonMigratedProjects(tree);
+    const { tree, nonMigratedProjectsBefore, getNonMigratedProjects } =
+      setupUntouchedProjectsCheck();
 
     await update(tree);
 
-    const nonMigratedProjectsAfter = getNonMigratedProjects(tree);
+    expect(nonMigratedProjectsBefore).toStrictEqual(
+      getNonMigratedProjects(tree)
+    );
+  });
 
-    expect(nonMigratedProjectsBefore).toStrictEqual(nonMigratedProjectsAfter);
+  it('should warn and skip projects without a name', async () => {
+    const { tree, loggerWarnSpy } = setupUnnamedProjectWarning();
+
+    await update(tree);
+
+    expect(loggerWarnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("doesn't have a name")
+    );
   });
 });

--- a/packages/ngx-deploy-npm/src/migrations/8.0.0/write-dist-folder-path-on-deploy-target-options.spec.ts
+++ b/packages/ngx-deploy-npm/src/migrations/8.0.0/write-dist-folder-path-on-deploy-target-options.spec.ts
@@ -94,8 +94,8 @@ describe('write-dist-folder-path-on-deploy-target-options migration', () => {
     addProjectConfiguration(tree, projectKey, unnamedProject);
 
     const projects = getProjects(tree);
-    const projectWithoutName = {
-      ...projects.get(projectKey)!,
+    const projectWithoutName: ProjectConfiguration = {
+      ...unnamedProject,
       name: undefined,
     };
     projects.set(projectKey, projectWithoutName);

--- a/packages/ngx-deploy-npm/src/utils/file-utils.spec.ts
+++ b/packages/ngx-deploy-npm/src/utils/file-utils.spec.ts
@@ -4,40 +4,46 @@ import { fileExists } from './file-utils';
 
 describe('File Utils', () => {
   describe('FileExists', () => {
-    let fakeFilePath: string;
+    function setupFileExists(
+      opts: {
+        fileShouldExist?: boolean;
+        filePath?: string;
+      } = {}
+    ) {
+      const {
+        fileShouldExist = true,
+        filePath = path.join('random', 'path', 'file', 'package.json'),
+      } = opts;
 
-    const setUp = ({ fileShouldExists }: { fileShouldExists: boolean }) => {
       const accessSpy = jest
         .spyOn(fs, 'access')
         .mockImplementation((_: fs.PathLike, callback: fs.NoParamCallback) => {
-          if (fileShouldExists) {
+          if (fileShouldExist) {
             callback(null);
           } else {
             callback(new Error('File not found'));
           }
         });
 
-      return {
-        accessSpy,
-      };
-    };
+      return { accessSpy, filePath };
+    }
 
-    beforeEach(() => {
-      fakeFilePath = path.join('random', 'path', 'file', 'package.json');
+    afterEach(() => {
+      jest.restoreAllMocks();
     });
 
     it('should indicate that the file exists', async () => {
-      setUp({ fileShouldExists: true });
+      const { filePath } = setupFileExists({ fileShouldExist: true });
 
-      const response = await fileExists(fakeFilePath);
+      const response = await fileExists(filePath);
 
       expect(response).toBe(true);
     });
 
-    it('should indicate that the file exists', async () => {
-      setUp({ fileShouldExists: false });
+    it('should indicate that the file does not exist', async () => {
+      const { filePath } = setupFileExists({ fileShouldExist: false });
 
-      const response = await fileExists(fakeFilePath);
+      const response = await fileExists(filePath);
 
       expect(response).toBe(false);
     });

--- a/packages/ngx-deploy-npm/src/utils/is-a-lib.spec.ts
+++ b/packages/ngx-deploy-npm/src/utils/is-a-lib.spec.ts
@@ -5,7 +5,7 @@ import * as mocks from '../__mocks__/mocks';
 import * as path from 'path';
 
 describe('is-a-lib', () => {
-  const setUp = () => {
+  function setup() {
     const projects: Record<
       'publishableLibrary' | 'nonPublishableLibrary' | 'app',
       ProjectConfiguration
@@ -16,17 +16,21 @@ describe('is-a-lib', () => {
     };
 
     return { projects };
-  };
+  }
 
   describe('isProjectAPublishableLib', () => {
-    const setUpIsProjectAPublishableLib = ({
-      shouldPackageJsonExists,
-      packageJsonContent,
-    }: {
-      shouldPackageJsonExists: boolean;
-      packageJsonContent?: { name: string; private?: boolean };
-    }) => {
-      const { projects } = setUp();
+    function setupIsProjectAPublishableLib(
+      opts: {
+        shouldPackageJsonExists?: boolean;
+        packageJsonContent?: { name: string; private?: boolean };
+      } = {}
+    ) {
+      const {
+        shouldPackageJsonExists = false,
+        packageJsonContent = { name: 'test-lib' },
+      } = opts;
+
+      const { projects } = setup();
       const mockTree = {} as Tree;
 
       const fileExistsMock = jest
@@ -35,17 +39,19 @@ describe('is-a-lib', () => {
 
       const readJsonMock = jest
         .spyOn({ readJson }, 'readJson')
-        .mockImplementation(() => packageJsonContent || { name: 'test-lib' });
+        .mockImplementation(() => packageJsonContent);
 
       return { fileExistsMock, readJsonMock, projects, mockTree };
-    };
+    }
 
-    afterEach(jest.restoreAllMocks);
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
 
     describe('when package.json exists', () => {
       describe('and package is public (private is false or undefined)', () => {
         it('should indicate that the project is a publishable library when private is false', async () => {
-          const { projects, mockTree } = setUpIsProjectAPublishableLib({
+          const { projects, mockTree } = setupIsProjectAPublishableLib({
             shouldPackageJsonExists: true,
             packageJsonContent: { name: 'test-lib', private: false },
           });
@@ -59,7 +65,7 @@ describe('is-a-lib', () => {
         });
 
         it('should indicate that the project is a publishable library when private is undefined', async () => {
-          const { projects, mockTree } = setUpIsProjectAPublishableLib({
+          const { projects, mockTree } = setupIsProjectAPublishableLib({
             shouldPackageJsonExists: true,
             packageJsonContent: { name: 'test-lib' },
           });
@@ -75,7 +81,7 @@ describe('is-a-lib', () => {
 
       describe('and package is private (private is true)', () => {
         it('should indicate that the project is not a publishable library', async () => {
-          const { projects, mockTree } = setUpIsProjectAPublishableLib({
+          const { projects, mockTree } = setupIsProjectAPublishableLib({
             shouldPackageJsonExists: true,
             packageJsonContent: { name: 'test-lib', private: true },
           });
@@ -92,7 +98,7 @@ describe('is-a-lib', () => {
 
     describe('when package.json does not exist', () => {
       it('should indicate that the project is not a publishable library', async () => {
-        const { projects, mockTree } = setUpIsProjectAPublishableLib({
+        const { projects, mockTree } = setupIsProjectAPublishableLib({
           shouldPackageJsonExists: false,
         });
 
@@ -108,7 +114,7 @@ describe('is-a-lib', () => {
     describe('file operations', () => {
       it('should look for package.json file in the project root', async () => {
         const { fileExistsMock, projects, mockTree } =
-          setUpIsProjectAPublishableLib({
+          setupIsProjectAPublishableLib({
             shouldPackageJsonExists: false,
           });
         const project = projects.nonPublishableLibrary;
@@ -122,7 +128,7 @@ describe('is-a-lib', () => {
 
       it('should read package.json content when file exists', async () => {
         const { readJsonMock, projects, mockTree } =
-          setUpIsProjectAPublishableLib({
+          setupIsProjectAPublishableLib({
             shouldPackageJsonExists: true,
             packageJsonContent: { name: 'test-lib', private: false },
           });


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

Unit tests used mixed patterns (`beforeEach` with outer `let`, spies created inside `it()` blocks, fragmented mock helpers). There was no documented project standard for test setup. Some code paths (deploy executor, engine edge cases, generator project-graph failures) had limited or no coverage.

Issue Number: N/A

## What is the new behavior?

- Adds `.cursor/rules/tests-sifers.mdc` and an AGENTS.md section mandating SIFERS (injectable setup functions returning fresh state) for all spec files.
- Refactors all 10 `ngx-deploy-npm` unit test files to call a single setup function at the start of each test; all mocks and spies are created inside setup.
- Adds `executor.spec.ts` and expands tests in engine, generator, and migration specs.
- Unit test statement coverage improves from ~96% to ~99.5%.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No