### PR TITLE
feat(ngx-deploy-npm): extend checkExisting with skip mode and checkTag

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,7 @@
     - [`--access`](#--access-install)
   - [deploy](#deploy)
     - [`--check-existing`](#--check-existing)
+    - [`--check-tag`](#--check-tag)
     - [`--package-version`](#--package-version)
     - [`--tag`](#--tag)
     - [`--access`](#--access)
@@ -337,10 +338,22 @@ The path must relative to project's root.
 - Example:
   - `nx deploy --check-existing=warning`
   - `nx deploy --check-existing=error`
+  - `nx deploy --check-existing=skip`
 
 Check if the package version already exists before publishing.
 If it exists and `--check-existing=warning`, it will skip the publishing and log a warning.
 If it exists and `--check-existing=error`, it will throw an error.
+If it exists and `--check-existing=skip`, it will skip the publishing silently (useful in CI).
+
+#### `--check-tag`
+
+- **optional**
+- Default: `false` (boolean)
+- Example:
+  - `nx deploy --check-existing=warning --check-tag`
+
+When set, the duplicate version check only runs when publishing to a non-`latest` tag.
+Publishing with the default `latest` tag (or without `--tag`) skips the check even if `--check-existing` is set.
 
 #### `--package-version`
 

--- a/packages/ngx-deploy-npm-e2e/src/check-existing.spec.ts
+++ b/packages/ngx-deploy-npm-e2e/src/check-existing.spec.ts
@@ -1,0 +1,79 @@
+import { uniq } from '@nx/plugin/testing';
+import { e2eTestTimeout, setup } from './utils';
+
+describe('checkExisting and checkTag', () => {
+  const registry = 'http://localhost:4873';
+
+  function deployCommand(
+    libName: string,
+    {
+      packageVersion = '0.0.0',
+      tag,
+      checkExisting,
+      checkTag,
+    }: {
+      packageVersion?: string;
+      tag?: string;
+      checkExisting?: 'error' | 'skip';
+      checkTag?: boolean;
+    } = {}
+  ) {
+    return [
+      `npx nx deploy ${libName}`,
+      `--registry=${registry}`,
+      `--packageVersion=${packageVersion}`,
+      tag ? `--tag="${tag}"` : '',
+      checkExisting ? `--checkExisting="${checkExisting}"` : '',
+      checkTag ? '--checkTag' : '',
+    ]
+      .filter(Boolean)
+      .join(' ');
+  }
+
+  it(
+    'should honor checkExisting skip and checkTag when publishing',
+    async () => {
+      const { processedLibs, tearDown, executeCommand } = await setup([
+        { name: uniq('check-existing-and-tag'), generator: 'minimal' },
+      ]);
+      const [lib] = processedLibs;
+
+      executeCommand(deployCommand(lib.name, { tag: 'e2e' }));
+
+      expect(() => {
+        executeCommand(
+          deployCommand(lib.name, { tag: 'e2e', checkExisting: 'skip' })
+        );
+      }).not.toThrow();
+
+      expect(() => {
+        executeCommand(
+          deployCommand(lib.name, {
+            tag: 'e2e',
+            checkExisting: 'error',
+            checkTag: true,
+          })
+        );
+      }).toThrow(/already exists in registry/);
+
+      expect(() => {
+        executeCommand(
+          deployCommand(lib.name, {
+            packageVersion: '0.0.1',
+            checkExisting: 'error',
+            checkTag: true,
+          })
+        );
+      }).not.toThrow();
+
+      expect(() => {
+        executeCommand(
+          `npm view ${lib.npmPackageName}@0.0.1 --registry=${registry}`
+        );
+      }).not.toThrow();
+
+      return tearDown();
+    },
+    e2eTestTimeout()
+  );
+});

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
@@ -193,6 +193,46 @@ describe('engine', () => {
       };
     };
 
+    it('should not run duplicate check when checkExisting is unset', async () => {
+      const { absoluteDistFolderPath, options } = versionCheckSetup({
+        options: {
+          ...defaultOption,
+        },
+      });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(spawn.spawnAsync).not.toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['view'])
+      );
+      expect(spawn.spawnAsync).toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['publish'])
+      );
+    });
+
+    it('should not run duplicate check when checkExisting is unset even if checkTag is enabled', async () => {
+      const { absoluteDistFolderPath, options } = versionCheckSetup({
+        options: {
+          ...defaultOption,
+          checkTag: true,
+          tag: 'next',
+        },
+      });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(spawn.spawnAsync).not.toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['view'])
+      );
+      expect(spawn.spawnAsync).toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['publish'])
+      );
+    });
+
     it('should skip publishing when package exists and checkExisting is warning', async () => {
       const { absoluteDistFolderPath, options, mockPackageJson } =
         versionCheckSetup({
@@ -317,10 +357,124 @@ describe('engine', () => {
       await engine.run(absoluteDistFolderPath, options);
 
       expect(loggerWarnSpy).toHaveBeenCalledWith(
-        expect.stringContaining(
-          'already exists in registry. Skipping  publish.'
-        )
+        expect.stringContaining('already exists in registry. Skipping publish.')
       );
+    });
+
+    it('should skip publishing silently when package exists and checkExisting is skip', async () => {
+      const { absoluteDistFolderPath, options, loggerWarnSpy } =
+        versionCheckSetup({
+          options: {
+            ...defaultOption,
+            checkExisting: 'skip',
+          },
+        });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(loggerWarnSpy).not.toHaveBeenCalled();
+      expect(spawn.spawnAsync).not.toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['publish'])
+      );
+    });
+
+    it('should include registry in warning when package exists and checkExisting is warning', async () => {
+      const registry = 'http://localhost:4873';
+      const {
+        absoluteDistFolderPath,
+        options,
+        loggerWarnSpy,
+        mockPackageJson,
+      } = versionCheckSetup({
+        options: {
+          ...defaultOption,
+          checkExisting: 'warning',
+          registry,
+        },
+      });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        `Package ${mockPackageJson.name}@${mockPackageJson.version} already exists in registry ${registry}. Skipping publish.`
+      );
+    });
+
+    it('should include registry in error when package exists and checkExisting is error', async () => {
+      const registry = 'http://localhost:4873';
+      const { absoluteDistFolderPath, options, mockPackageJson } =
+        versionCheckSetup({
+          options: {
+            ...defaultOption,
+            checkExisting: 'error',
+            registry,
+          },
+        });
+
+      await expect(() =>
+        engine.run(absoluteDistFolderPath, options)
+      ).rejects.toThrow(
+        `Package ${mockPackageJson.name}@${mockPackageJson.version} already exists in registry ${registry}.`
+      );
+    });
+
+    it('should skip duplicate check when checkTag is true and tag is latest', async () => {
+      const { absoluteDistFolderPath, options } = versionCheckSetup({
+        options: {
+          ...defaultOption,
+          checkExisting: 'warning',
+          checkTag: true,
+        },
+      });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(spawn.spawnAsync).not.toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['view'])
+      );
+      expect(spawn.spawnAsync).toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['publish'])
+      );
+    });
+
+    it('should skip duplicate check when checkTag is true and tag is unset', async () => {
+      const { absoluteDistFolderPath, options } = versionCheckSetup({
+        options: {
+          ...defaultOption,
+          checkExisting: 'error',
+          checkTag: true,
+        },
+      });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(spawn.spawnAsync).not.toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['view'])
+      );
+    });
+
+    it('should run duplicate check when checkTag is true and tag is not latest', async () => {
+      const { absoluteDistFolderPath, options, mockPackageJson } =
+        versionCheckSetup({
+          options: {
+            ...defaultOption,
+            checkExisting: 'warning',
+            checkTag: true,
+            tag: 'next',
+          },
+        });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(spawn.spawnAsync).toHaveBeenCalledWith('npm', [
+        'view',
+        `${mockPackageJson.name}@${mockPackageJson.version}`,
+        'version',
+      ]);
     });
   });
 

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
@@ -6,7 +6,7 @@ import { setPackageVersion, NpmPublishOptions, spawnAsync } from '../utils';
 import { DeployExecutorOptions } from '../schema';
 
 type PackageInfo = { name: string; version: string };
-type ExistingPackagePolicy = 'error' | 'warning';
+type ExistingPackagePolicy = 'error' | 'warning' | 'skip';
 
 async function checkIfPackageExists(
   packageName: string,
@@ -45,8 +45,14 @@ function formatAlreadyExistsMessage(
   return `Package ${packageInfo.name}@${packageInfo.version} already exists in registry${registrySuffix}.`;
 }
 
-function formatAlreadyExistsSkipMessage(packageInfo: PackageInfo): string {
-  return `Package ${packageInfo.name}@${packageInfo.version} already exists in registry. Skipping  publish.`;
+function formatAlreadyExistsSkipPublishMessage(
+  packageInfo: PackageInfo,
+  registry?: string
+): string {
+  return `${formatAlreadyExistsMessage(
+    packageInfo,
+    registry
+  )} Skipping publish.`;
 }
 
 const whenPackageExists: Record<
@@ -56,15 +62,31 @@ const whenPackageExists: Record<
   error: (packageInfo, registry) => {
     throw new Error(formatAlreadyExistsMessage(packageInfo, registry));
   },
-  warning: packageInfo => {
-    logger.warn(formatAlreadyExistsSkipMessage(packageInfo));
+  warning: (packageInfo, registry) => {
+    logger.warn(formatAlreadyExistsSkipPublishMessage(packageInfo, registry));
   },
+  skip: () => undefined,
 };
 
 function isCheckExistingEnabled(
   checkExisting: DeployExecutorOptions['checkExisting']
 ): checkExisting is ExistingPackagePolicy {
-  return !!checkExisting && ['error', 'warning'].includes(checkExisting);
+  return (
+    !!checkExisting && ['error', 'warning', 'skip'].includes(checkExisting)
+  );
+}
+
+function shouldRunExistingCheck(options: DeployExecutorOptions): boolean {
+  if (!isCheckExistingEnabled(options.checkExisting)) {
+    return false;
+  }
+
+  if (options.checkTag) {
+    const publishTag = options.tag ?? 'latest';
+    return publishTag !== 'latest';
+  }
+
+  return true;
 }
 
 function logDryRunBanner(options: DeployExecutorOptions): void {
@@ -92,7 +114,12 @@ async function ensurePublishAllowed(
   options: DeployExecutorOptions,
   npmOptions: NpmPublishOptions
 ): Promise<boolean> {
-  if (!isCheckExistingEnabled(options.checkExisting)) {
+  const { checkExisting } = options;
+
+  if (
+    !isCheckExistingEnabled(checkExisting) ||
+    !shouldRunExistingCheck(options)
+  ) {
     return true;
   }
 
@@ -107,7 +134,7 @@ async function ensurePublishAllowed(
     return true;
   }
 
-  whenPackageExists[options.checkExisting](packageInfo, options.registry);
+  whenPackageExists[checkExisting](packageInfo, options.registry);
 
   return false;
 }

--- a/packages/ngx-deploy-npm/src/executors/deploy/schema.d.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/schema.d.ts
@@ -30,5 +30,9 @@ export interface DeployExecutorOptions {
   /**
    * Check if the package version already exists before publishing
    */
-  checkExisting?: 'error' | 'warning';
+  checkExisting?: 'error' | 'warning' | 'skip';
+  /**
+   * When true, only run the checkExisting duplicate version check when publishing to a non-latest tag
+   */
+  checkTag?: boolean;
 }

--- a/packages/ngx-deploy-npm/src/executors/deploy/schema.json
+++ b/packages/ngx-deploy-npm/src/executors/deploy/schema.json
@@ -39,8 +39,13 @@
     },
     "checkExisting": {
       "type": "string",
-      "description": "How to handle existing package versions: 'warning' to continue with a warning, 'error' to abort publishing",
-      "enum": ["warning", "error"]
+      "description": "How to handle existing package versions: 'warning' to skip publishing with a warning, 'error' to abort publishing, 'skip' to skip publishing silently",
+      "enum": ["warning", "error", "skip"]
+    },
+    "checkTag": {
+      "type": "boolean",
+      "description": "When true, only run the checkExisting duplicate version check when publishing to a non-latest tag",
+      "default": false
     }
   },
   "required": ["distFolderPath"]


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

`--check-existing` supports only `warning` and `error`. When a duplicate version is found, warning/error messages omit the registry URL in the warning path, and duplicate checks always run regardless of the publish dist-tag.

Issue Number: N/A

## What is the new behavior?

- **`checkExisting: 'skip'`** — silently skips publishing when the version already exists (useful in CI).
- **`checkTag`** — when enabled, the duplicate version check only runs for non-`latest` tags; publishing to `latest` (or without `--tag`) skips the check even if `--check-existing` is set.
- **Registry messaging** — warning and error messages consistently include the registry URL when `--registry` is provided.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- Unit tests added in `engine.spec.ts`.
- Single consolidated e2e test in `check-existing.spec.ts` covering `skip` and `checkTag` to keep e2e runtime low.