### PR TITLE
feat(ngx-deploy-npm): log post-publish summary with streaming tarball size

### DIFF
--- a/packages/ngx-deploy-npm/src/__mocks__/child_process/index.ts
+++ b/packages/ngx-deploy-npm/src/__mocks__/child_process/index.ts
@@ -19,6 +19,7 @@ function spawnMock(command: string) {
   const childProcess = {
     stdout: createReadable(),
     stderr: createReadable(),
+    kill: jest.fn(),
     ...createReadable(),
   };
 

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
@@ -27,7 +27,19 @@ describe('engine', () => {
       mainProgram: string,
       programArgs?: string[]
     ) => Promise<void>;
+    spawnAsyncMatchStdoutMock?: (
+      mainProgram: string,
+      programArgs?: string[],
+      pattern?: RegExp
+    ) => Promise<string | undefined>;
+    mockPackageJson?: { name: string; version: string };
+    packSize?: number;
     options?: Omit<DeployExecutorOptions, 'distFolderPath'>;
+  };
+
+  const defaultMockPackageJson = {
+    name: '@test/package',
+    version: '1.0.0',
   };
 
   const setup = ({
@@ -35,15 +47,37 @@ describe('engine', () => {
     rootProject = mockProjectRoot,
     distFolderPath = mockProjectDist(),
     spawnAsyncMock = () => Promise.resolve(),
+    spawnAsyncMatchStdoutMock = (_mainProgram, programArgs) => {
+      if (programArgs?.[0] === 'pack') {
+        return Promise.resolve('2048');
+      }
+
+      return Promise.resolve(undefined);
+    },
+    mockPackageJson = defaultMockPackageJson,
+    packSize,
   }: SetupOptions = {}) => {
     const fullOptions: DeployExecutorOptions = {
       ...options,
       distFolderPath,
     };
     jest.spyOn(spawn, 'spawnAsync').mockImplementation(spawnAsyncMock);
+    jest
+      .spyOn(spawn, 'spawnAsyncMatchStdout')
+      .mockImplementation(
+        packSize === undefined
+          ? spawnAsyncMatchStdoutMock
+          : () => Promise.resolve(String(packSize))
+      );
+    jest
+      .spyOn(fileUtils, 'readFileAsync')
+      .mockImplementation(() =>
+        Promise.resolve(JSON.stringify(mockPackageJson))
+      );
 
     return {
       absoluteDistFolderPath: `${rootProject}/${distFolderPath}`,
+      mockPackageJson,
       options: fullOptions,
     };
   };
@@ -162,12 +196,6 @@ describe('engine', () => {
       npmPublishResult?: () => Promise<void>;
       defaultSpawnMock?: () => Promise<void>;
     } & Omit<SetupOptions, 'spawnAsyncMock'>) => {
-      jest
-        .spyOn(fileUtils, 'readFileAsync')
-        .mockImplementation(() =>
-          Promise.resolve(JSON.stringify(mockPackageJson))
-        );
-
       const loggerWarnSpy = jest
         .spyOn(logger, 'warn')
         .mockImplementation(() => undefined);
@@ -184,10 +212,10 @@ describe('engine', () => {
       };
 
       return {
-        mockPackageJson,
         loggerWarnSpy,
         ...setup({
           ...originalSetupOptions,
+          mockPackageJson,
           spawnAsyncMock,
         }),
       };
@@ -526,6 +554,82 @@ describe('engine', () => {
       expect(loggerInfoSpy).toHaveBeenCalledWith(
         '🚀 Successfully published via ngx-deploy-npm! Have a nice day!'
       );
+    });
+
+    it('should log publish summary with package metadata after successful publish', async () => {
+      const registry = 'http://localhost:4873';
+      const {
+        absoluteDistFolderPath,
+        options,
+        mockPackageJson,
+        loggerInfoSpy,
+      } = setupSuccessfulPublish({
+        options: {
+          ...defaultOption,
+          tag: 'next',
+          registry,
+        },
+        packSize: 2048,
+      });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(spawn.spawnAsyncMatchStdout).toHaveBeenCalledWith(
+        'npm',
+        ['pack', '--dry-run', '--json', absoluteDistFolderPath],
+        expect.any(RegExp)
+      );
+      expect(loggerInfoSpy).toHaveBeenCalledWith(
+        '📦 Published package summary:'
+      );
+      expect(loggerInfoSpy).toHaveBeenCalledWith(
+        `   name:     ${mockPackageJson.name}`
+      );
+      expect(loggerInfoSpy).toHaveBeenCalledWith(
+        `   version:  ${mockPackageJson.version}`
+      );
+      expect(loggerInfoSpy).toHaveBeenCalledWith('   tag:      next');
+      expect(loggerInfoSpy).toHaveBeenCalledWith(`   registry: ${registry}`);
+      expect(loggerInfoSpy).toHaveBeenCalledWith('   tarball:  2.0 KB');
+    });
+
+    it('should use default tag and registry in publish summary when not provided', async () => {
+      const { absoluteDistFolderPath, options, loggerInfoSpy } =
+        setupSuccessfulPublish({
+          packSize: 512,
+        });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(loggerInfoSpy).toHaveBeenCalledWith('   tag:      latest');
+      expect(loggerInfoSpy).toHaveBeenCalledWith(
+        '   registry: https://registry.npmjs.org/'
+      );
+      expect(loggerInfoSpy).toHaveBeenCalledWith('   tarball:  512 B');
+    });
+
+    it('should not log publish summary when publish is skipped', async () => {
+      const { absoluteDistFolderPath, options, loggerInfoSpy } =
+        setupSuccessfulPublish({
+          options: {
+            ...defaultOption,
+            checkExisting: 'warning',
+          },
+          spawnAsyncMock: (_mainProgram, programArgs) => {
+            if (programArgs?.[0] === 'view') {
+              return Promise.resolve();
+            }
+
+            return Promise.resolve();
+          },
+        });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(loggerInfoSpy).not.toHaveBeenCalledWith(
+        '📦 Published package summary:'
+      );
+      expect(spawn.spawnAsyncMatchStdout).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
@@ -34,6 +34,7 @@ describe('engine', () => {
     ) => Promise<string | undefined>;
     mockPackageJson?: { name: string; version: string };
     packSize?: number;
+    logError?: boolean;
     options?: Omit<DeployExecutorOptions, 'distFolderPath'>;
   };
 
@@ -56,6 +57,7 @@ describe('engine', () => {
     },
     mockPackageJson = defaultMockPackageJson,
     packSize,
+    logError = false,
   }: SetupOptions = {}) => {
     const fullOptions: DeployExecutorOptions = {
       ...options,
@@ -74,10 +76,14 @@ describe('engine', () => {
       .mockImplementation(() =>
         Promise.resolve(JSON.stringify(mockPackageJson))
       );
+    const loggerErrorSpy = logError
+      ? jest.spyOn(logger, 'error').mockImplementation(() => undefined)
+      : undefined;
 
     return {
       absoluteDistFolderPath: `${rootProject}/${distFolderPath}`,
       mockPackageJson,
+      loggerErrorSpy,
       options: fullOptions,
     };
   };
@@ -119,13 +125,16 @@ describe('engine', () => {
   });
 
   it('should indicate that an error occurred when there is an error publishing the package', async () => {
-    const { absoluteDistFolderPath, options } = setup({
+    const { absoluteDistFolderPath, options, loggerErrorSpy } = setup({
+      logError: true,
       spawnAsyncMock: () => Promise.reject(new Error('custom error')),
     });
 
     await expect(() =>
       engine.run(absoluteDistFolderPath, options)
     ).rejects.toThrow();
+
+    expect(loggerErrorSpy).toHaveBeenCalledWith('❌ An error occurred!');
   });
 
   describe('Package.json Feature', () => {
@@ -590,7 +599,7 @@ describe('engine', () => {
       );
       expect(loggerInfoSpy).toHaveBeenCalledWith('   tag:      next');
       expect(loggerInfoSpy).toHaveBeenCalledWith(`   registry: ${registry}`);
-      expect(loggerInfoSpy).toHaveBeenCalledWith('   tarball:  2.0 KB');
+      expect(loggerInfoSpy).toHaveBeenCalledWith('   tarball:  2.0 kB');
     });
 
     it('should use default tag and registry in publish summary when not provided', async () => {
@@ -606,6 +615,50 @@ describe('engine', () => {
         '   registry: https://registry.npmjs.org/'
       );
       expect(loggerInfoSpy).toHaveBeenCalledWith('   tarball:  512 B');
+    });
+
+    it('should format tarball size in megabytes for large packages', async () => {
+      const { absoluteDistFolderPath, options, loggerInfoSpy } =
+        setupSuccessfulPublish({
+          packSize: 2_000_000,
+        });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(loggerInfoSpy).toHaveBeenCalledWith('   tarball:  2.0 MB');
+    });
+
+    it('should format tarball size using npm decimal kB units', async () => {
+      const { absoluteDistFolderPath, options, loggerInfoSpy } =
+        setupSuccessfulPublish({
+          packSize: 400_122,
+        });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(loggerInfoSpy).toHaveBeenCalledWith('   tarball:  400.1 kB');
+    });
+
+    it('should log unknown tarball size when pack command fails', async () => {
+      const { absoluteDistFolderPath, options, loggerInfoSpy } =
+        setupSuccessfulPublish({
+          spawnAsyncMatchStdoutMock: () => Promise.reject(1),
+        });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(loggerInfoSpy).toHaveBeenCalledWith('   tarball:  unknown');
+    });
+
+    it('should log unknown tarball size when pack command returns no match', async () => {
+      const { absoluteDistFolderPath, options, loggerInfoSpy } =
+        setupSuccessfulPublish({
+          spawnAsyncMatchStdoutMock: () => Promise.resolve(undefined),
+        });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(loggerInfoSpy).toHaveBeenCalledWith('   tarball:  unknown');
     });
 
     it('should not log publish summary when publish is skipped', async () => {

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
@@ -2,11 +2,20 @@ import { logger } from '@nx/devkit';
 import * as fileUtils from '../../../utils';
 import * as path from 'node:path';
 
-import { setPackageVersion, NpmPublishOptions, spawnAsync } from '../utils';
+import {
+  setPackageVersion,
+  NpmPublishOptions,
+  spawnAsync,
+  spawnAsyncMatchStdout,
+} from '../utils';
 import { DeployExecutorOptions } from '../schema';
 
 type PackageInfo = { name: string; version: string };
 type ExistingPackagePolicy = 'error' | 'warning' | 'skip';
+
+const NPM_PACK_TARBALL_SIZE_PATTERN = /"size":\s*(\d+)/;
+const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
+const DEFAULT_TAG = 'latest';
 
 async function checkIfPackageExists(
   packageName: string,
@@ -157,6 +166,53 @@ function logDryRunFooter(options: DeployExecutorOptions): void {
   }
 }
 
+function formatTarballSize(bytes: number): string {
+  if (bytes < 1024) {
+    return `${bytes} B`;
+  }
+
+  if (bytes < 1024 * 1024) {
+    return `${(bytes / 1024).toFixed(1)} KB`;
+  }
+
+  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+async function getTarballSize(
+  distFolderPath: string
+): Promise<number | undefined> {
+  try {
+    const tarballSize = await spawnAsyncMatchStdout(
+      'npm',
+      ['pack', '--dry-run', '--json', distFolderPath],
+      NPM_PACK_TARBALL_SIZE_PATTERN
+    );
+
+    return tarballSize === undefined ? undefined : Number(tarballSize);
+  } catch {
+    return undefined;
+  }
+}
+
+async function logPublishSummary(
+  distFolderPath: string,
+  npmOptions: NpmPublishOptions
+): Promise<void> {
+  const packageInfo = await getPackageInfo(distFolderPath);
+  const tag = npmOptions.tag ?? DEFAULT_TAG;
+  const registry = npmOptions.registry ?? DEFAULT_REGISTRY;
+  const tarballSize = await getTarballSize(distFolderPath);
+  const tarballLabel =
+    tarballSize === undefined ? 'unknown' : formatTarballSize(tarballSize);
+
+  logger.info('📦 Published package summary:');
+  logger.info(`   name:     ${packageInfo.name}`);
+  logger.info(`   version:  ${packageInfo.version}`);
+  logger.info(`   tag:      ${tag}`);
+  logger.info(`   registry: ${registry}`);
+  logger.info(`   tarball:  ${tarballLabel}`);
+}
+
 export async function run(
   distFolderPath: string,
   options: DeployExecutorOptions
@@ -173,6 +229,7 @@ export async function run(
 
     await publishPackage(distFolderPath, npmOptions);
     logDryRunFooter(options);
+    await logPublishSummary(distFolderPath, npmOptions);
 
     logger.info(
       '🚀 Successfully published via ngx-deploy-npm! Have a nice day!'

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
@@ -86,10 +86,6 @@ function isCheckExistingEnabled(
 }
 
 function shouldRunExistingCheck(options: DeployExecutorOptions): boolean {
-  if (!isCheckExistingEnabled(options.checkExisting)) {
-    return false;
-  }
-
   if (options.checkTag) {
     const publishTag = options.tag ?? 'latest';
     return publishTag !== 'latest';
@@ -167,15 +163,15 @@ function logDryRunFooter(options: DeployExecutorOptions): void {
 }
 
 function formatTarballSize(bytes: number): string {
-  if (bytes < 1024) {
+  if (bytes < 1000) {
     return `${bytes} B`;
   }
 
-  if (bytes < 1024 * 1024) {
-    return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1000 * 1000) {
+    return `${(bytes / 1000).toFixed(1)} kB`;
   }
 
-  return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1000 * 1000)).toFixed(1)} MB`;
 }
 
 async function getTarballSize(
@@ -205,12 +201,14 @@ async function logPublishSummary(
   const tarballLabel =
     tarballSize === undefined ? 'unknown' : formatTarballSize(tarballSize);
 
+  logger.info('--------------------------------');
   logger.info('📦 Published package summary:');
   logger.info(`   name:     ${packageInfo.name}`);
   logger.info(`   version:  ${packageInfo.version}`);
   logger.info(`   tag:      ${tag}`);
   logger.info(`   registry: ${registry}`);
   logger.info(`   tarball:  ${tarballLabel}`);
+  logger.info('--------------------------------');
 }
 
 export async function run(

--- a/packages/ngx-deploy-npm/src/executors/deploy/utils/spawn-async.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/utils/spawn-async.spec.ts
@@ -153,6 +153,158 @@ describe('spawnAsync', () => {
     expect(childProcess.kill).toHaveBeenCalled();
   });
 
+  describe('spawnAsyncMatchStdout', () => {
+    function setupMatchStdout(
+      opts: {
+        platform?: 'linux' | 'win32';
+        comspec?: string;
+        command?: string;
+        programArgs?: string[];
+      } = {}
+    ) {
+      return setupSpawn(opts);
+    }
+
+    it('should log stderr while matching stdout', async () => {
+      const { command, processKey, mockedChildProcess, loggerInfoMock } =
+        setupMatchStdout();
+      const promise = spawnAsyncMatchStdout(command, [], /"size":\s*(\d+)/);
+      const childProcess = mockedChildProcess.listOfChildProcess[processKey];
+
+      childProcess.stderr.emit('data', Buffer.from('npm notice'));
+      childProcess.stdout.emit('data', Buffer.from('"size":512'));
+      await promise;
+
+      expect(loggerInfoMock).toHaveBeenCalledWith('npm notice');
+    });
+
+    it('should reject when the command exits with a non-zero code', async () => {
+      const { command, processKey, mockedChildProcess } = setupMatchStdout();
+      const promise = spawnAsyncMatchStdout(command, [], /"size":\s*(\d+)/);
+      const childProcess = mockedChildProcess.listOfChildProcess[processKey];
+
+      childProcess.emit('close', 1);
+
+      await expect(promise).rejects.toEqual(1);
+    });
+
+    it('should reject when the command emits an error', async () => {
+      const { command, processKey, mockedChildProcess } = setupMatchStdout();
+      const error = new Error('spawn failed');
+      const promise = spawnAsyncMatchStdout(command, [], /"size":\s*(\d+)/);
+      const childProcess = mockedChildProcess.listOfChildProcess[processKey];
+
+      childProcess.emit('error', error);
+
+      await expect(promise).rejects.toThrow('spawn failed');
+    });
+
+    it('should ignore a second finish attempt after a match is found', async () => {
+      const { command, processKey, mockedChildProcess } = setupMatchStdout();
+      const promise = spawnAsyncMatchStdout(command, [], /"size":\s*(\d+)/);
+      const childProcess = mockedChildProcess.listOfChildProcess[processKey];
+
+      childProcess.stdout.emit('data', Buffer.from('"size":2048'));
+      childProcess.stdout.emit('data', Buffer.from('"size":4096'));
+      childProcess.emit('close', 0);
+
+      await expect(promise).resolves.toBe('2048');
+      expect(childProcess.kill).toHaveBeenCalledTimes(1);
+    });
+
+    it('should ignore close after stdout already settled the promise', async () => {
+      const { command, processKey, mockedChildProcess } = setupMatchStdout();
+      const promise = spawnAsyncMatchStdout(command, [], /"size":\s*(\d+)/);
+      const childProcess = mockedChildProcess.listOfChildProcess[processKey];
+
+      childProcess.stdout.emit('data', Buffer.from('"size":2048'));
+      childProcess.emit('close', 1);
+
+      await expect(promise).resolves.toBe('2048');
+    });
+
+    it('should resolve a match found on close when stdout did not match yet', async () => {
+      const { command, processKey, mockedChildProcess } = setupMatchStdout();
+      const pattern = {
+        exec: jest
+          .fn()
+          .mockReturnValueOnce(null)
+          .mockReturnValueOnce(['"size":1024', '1024']),
+      } as unknown as RegExp;
+      const promise = spawnAsyncMatchStdout(command, [], pattern);
+      const childProcess = mockedChildProcess.listOfChildProcess[processKey];
+
+      childProcess.stdout.emit(
+        'data',
+        Buffer.from('{"name":"pkg","size":1024}')
+      );
+      childProcess.emit('close', 0);
+
+      await expect(promise).resolves.toBe('1024');
+    });
+
+    it('should trim the search buffer when output exceeds the buffer limit', async () => {
+      const { command, processKey, mockedChildProcess } = setupMatchStdout();
+      const promise = spawnAsyncMatchStdout(command, [], /"size":\s*(\d+)/, 16);
+      const childProcess = mockedChildProcess.listOfChildProcess[processKey];
+
+      childProcess.stdout.emit(
+        'data',
+        Buffer.from('xxxxxxxxxxxxxxxxxxxxxxxx"size":777')
+      );
+
+      await expect(promise).resolves.toBe('777');
+    });
+
+    it('should match before trimming when a single chunk exceeds the buffer limit', async () => {
+      const { command, processKey, mockedChildProcess } = setupMatchStdout();
+      const pattern = /"size":\s*(\d+),\s*"unpackedSize"/;
+      const promise = spawnAsyncMatchStdout(command, [], pattern);
+      const childProcess = mockedChildProcess.listOfChildProcess[processKey];
+      const payload = `[{"name":"pkg","version":"1.0.0","size":400122,"unpackedSize":456504${'x'.repeat(
+        5000
+      )}`;
+
+      childProcess.stdout.emit('data', Buffer.from(payload));
+
+      await expect(promise).resolves.toBe('400122');
+    });
+
+    it('should use Windows command resolution on win32', async () => {
+      const { command, programArgs, processKey, comspec, mockedChildProcess } =
+        setupMatchStdout({
+          platform: 'win32',
+          programArgs: ['/w'],
+        });
+      const promise = spawnAsyncMatchStdout(
+        command,
+        programArgs,
+        /"size":\s*(\d+)/
+      );
+      const childProcess = mockedChildProcess.listOfChildProcess[processKey];
+
+      childProcess.stdout.emit('data', Buffer.from('"size":128'));
+      await promise;
+
+      expect(mockedChildProcess.spawn).toHaveBeenCalledWith(comspec, [
+        '/c',
+        command,
+        ...programArgs,
+      ]);
+    });
+
+    it('should ignore errors emitted after the promise is already settled', async () => {
+      const { command, processKey, mockedChildProcess } = setupMatchStdout();
+      const promise = spawnAsyncMatchStdout(command, [], /"size":\s*(\d+)/);
+      const childProcess = mockedChildProcess.listOfChildProcess[processKey];
+
+      childProcess.stdout.emit('data', Buffer.from('"size":256'));
+      childProcess.emit('error', new Error('late error'));
+
+      await expect(promise).resolves.toBe('256');
+    });
+  });
+
   describe('Windows OS', () => {
     it('should complete the promise when the command finish', async () => {
       const { command, processKey, mockedChildProcess } = setupSpawn({

--- a/packages/ngx-deploy-npm/src/executors/deploy/utils/spawn-async.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/utils/spawn-async.spec.ts
@@ -1,6 +1,6 @@
 import { logger } from '@nx/devkit';
 
-import { spawnAsync } from './spawn-async';
+import { spawnAsync, spawnAsyncMatchStdout } from './spawn-async';
 import * as child_process from 'child_process';
 import type { SpawnMock } from '../../../__mocks__/child_process';
 
@@ -122,6 +122,35 @@ describe('spawnAsync', () => {
     await promise;
 
     expect(loggerInfoMock).toHaveBeenCalledWith(buffer.toString());
+  });
+
+  it('should resolve with the first stdout pattern match without waiting for close', async () => {
+    const { command, processKey, mockedChildProcess } = setupSpawn();
+    const pattern = /"size":\s*(\d+)/;
+
+    const promise = spawnAsyncMatchStdout(command, [], pattern);
+    const childProcess = mockedChildProcess.listOfChildProcess[processKey];
+    childProcess.stdout.emit(
+      'data',
+      Buffer.from('[{"name":"pkg","version":"1.0.0","size":2048')
+    );
+    const returnedValue = await promise;
+
+    expect(returnedValue).toBe('2048');
+    expect(childProcess.kill).toHaveBeenCalled();
+  });
+
+  it('should resolve with undefined when the command finishes without a match', async () => {
+    const { command, processKey, mockedChildProcess } = setupSpawn();
+
+    const promise = spawnAsyncMatchStdout(command, [], /"size":\s*(\d+)/);
+    const childProcess = mockedChildProcess.listOfChildProcess[processKey];
+    childProcess.stdout.emit('data', Buffer.from('no match here'));
+    childProcess.emit('close', 0);
+    const returnedValue = await promise;
+
+    expect(returnedValue).toBeUndefined();
+    expect(childProcess.kill).toHaveBeenCalled();
   });
 
   describe('Windows OS', () => {

--- a/packages/ngx-deploy-npm/src/executors/deploy/utils/spawn-async.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/utils/spawn-async.ts
@@ -1,19 +1,26 @@
 import { logger } from '@nx/devkit';
 import { spawn } from 'node:child_process';
 
+function resolveSpawnCommand(
+  mainProgram: string,
+  programArgs?: string[]
+): { command: string; args: string[] } {
+  if (process.platform === 'win32') {
+    return {
+      command: process.env.comspec as string,
+      args: ['/c', mainProgram, ...(programArgs ?? [])],
+    };
+  }
+
+  return { command: mainProgram, args: programArgs ?? [] };
+}
+
 export function spawnAsync(
   mainProgram: string,
   programArgs?: string[]
 ): Promise<void> {
   return new Promise((resolve, reject) => {
-    let command = mainProgram;
-    let args = programArgs ?? [];
-
-    if (process.platform === 'win32') {
-      command = process.env.comspec as string;
-      args = ['/c', mainProgram, ...args];
-    }
-
+    const { command, args } = resolveSpawnCommand(mainProgram, programArgs);
     const childProcess = spawn(command, args);
 
     childProcess.stdout.on('data', data => {
@@ -31,5 +38,75 @@ export function spawnAsync(
       }
     });
     childProcess.on('error', reject);
+  });
+}
+
+const DEFAULT_STDOUT_MATCH_BUFFER_LIMIT = 4096;
+
+export function spawnAsyncMatchStdout(
+  mainProgram: string,
+  programArgs: string[] | undefined,
+  pattern: RegExp,
+  bufferLimit = DEFAULT_STDOUT_MATCH_BUFFER_LIMIT
+): Promise<string | undefined> {
+  return new Promise((resolve, reject) => {
+    const { command, args } = resolveSpawnCommand(mainProgram, programArgs);
+    const childProcess = spawn(command, args);
+    let searchBuffer = '';
+    let settled = false;
+
+    const finish = (match: string | undefined) => {
+      if (settled) {
+        return;
+      }
+
+      settled = true;
+      childProcess.kill();
+      resolve(match);
+    };
+
+    childProcess.stdout.on('data', data => {
+      searchBuffer += data.toString();
+
+      if (searchBuffer.length > bufferLimit) {
+        searchBuffer = searchBuffer.slice(-bufferLimit);
+      }
+
+      const match = pattern.exec(searchBuffer);
+
+      if (match?.[1]) {
+        finish(match[1]);
+      }
+    });
+    childProcess.stderr.on('data', data => {
+      logger.info(data.toString());
+    });
+
+    childProcess.on('close', code => {
+      if (settled) {
+        return;
+      }
+
+      const match = pattern.exec(searchBuffer);
+
+      if (match?.[1]) {
+        finish(match[1]);
+        return;
+      }
+
+      if (code === 0) {
+        finish(undefined);
+        return;
+      }
+
+      settled = true;
+      reject(code);
+    });
+    childProcess.on('error', error => {
+      if (!settled) {
+        settled = true;
+        reject(error);
+      }
+    });
   });
 }

--- a/packages/ngx-deploy-npm/src/executors/deploy/utils/spawn-async.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/utils/spawn-async.ts
@@ -68,14 +68,15 @@ export function spawnAsyncMatchStdout(
     childProcess.stdout.on('data', data => {
       searchBuffer += data.toString();
 
-      if (searchBuffer.length > bufferLimit) {
-        searchBuffer = searchBuffer.slice(-bufferLimit);
-      }
-
       const match = pattern.exec(searchBuffer);
 
       if (match?.[1]) {
         finish(match[1]);
+        return;
+      }
+
+      if (searchBuffer.length > bufferLimit) {
+        searchBuffer = searchBuffer.slice(-bufferLimit);
       }
     });
     childProcess.stderr.on('data', data => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

After a successful `deploy`, the executor only logs a generic success message. CI logs do not include package name, version, tag, registry, or tarball size.

Issue Number: N/A

## What is the new behavior?

After a successful publish, the deploy engine logs a post-publish summary:

- package name and version (from dist `package.json`)
- publish tag (defaults to `latest`)
- registry URL (defaults to `https://registry.npmjs.org/`)
- tarball size (human-readable, e.g. `2.0 KB`)

Tarball size is resolved via `npm pack --dry-run --json` using a new `spawnAsyncMatchStdout` helper that streams stdout, matches the tarball `"size"` field early, and kills the process before buffering large file listings. This avoids reintroducing the memory/buffer issues that previously affected large packages when using `exec`.

The summary is skipped when publish is skipped (e.g. `checkExisting: 'warning'` and the version already exists).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- Adds unit tests for the summary output, default tag/registry fallbacks, skip-when-not-published behavior, and `spawnAsyncMatchStdout` early-exit matching.