### PR TITLE
feat(ngx-deploy-npm): forward npm publish passthrough flags

### DIFF
--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
@@ -101,7 +101,6 @@ describe('engine', () => {
       '--otp',
       'someValue',
       '--dry-run',
-      'true',
       '--registry',
       'http://localhost:4873',
     ];
@@ -121,6 +120,50 @@ describe('engine', () => {
       'publish',
       absoluteDistFolderPath,
       ...expectedOptionsArray,
+    ]);
+  });
+
+  it('should forward common npm publish passthrough flags', async () => {
+    const expectedOptionsArray = [
+      '--access',
+      npmAccess.public,
+      '--provenance',
+      '--ignore-scripts',
+    ];
+    const { absoluteDistFolderPath, options } = setup({
+      options: {
+        access: npmAccess.public,
+        provenance: true,
+        ignoreScripts: true,
+      },
+    });
+
+    await engine.run(absoluteDistFolderPath, options);
+
+    expect(spawn.spawnAsync).toHaveBeenCalledWith('npm', [
+      'publish',
+      absoluteDistFolderPath,
+      ...expectedOptionsArray,
+    ]);
+  });
+
+  it('should forward provenanceFile as a string option', async () => {
+    const { absoluteDistFolderPath, options } = setup({
+      options: {
+        access: npmAccess.public,
+        provenanceFile: '/tmp/provenance.json',
+      },
+    });
+
+    await engine.run(absoluteDistFolderPath, options);
+
+    expect(spawn.spawnAsync).toHaveBeenCalledWith('npm', [
+      'publish',
+      absoluteDistFolderPath,
+      '--access',
+      npmAccess.public,
+      '--provenance-file',
+      '/tmp/provenance.json',
     ]);
   });
 

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
@@ -249,6 +249,9 @@ function extractOnlyNPMOptions({
   otp,
   dryRun,
   registry,
+  provenance,
+  provenanceFile,
+  ignoreScripts,
 }: DeployExecutorOptions): NpmPublishOptions {
   return {
     access,
@@ -256,6 +259,9 @@ function extractOnlyNPMOptions({
     otp,
     dryRun,
     registry,
+    provenance,
+    provenanceFile,
+    ignoreScripts,
   };
 }
 
@@ -264,19 +270,26 @@ function toKebabCase(str: string) {
 }
 
 function getOptionsStringArr(options: NpmPublishOptions): string[] {
-  return (
-    Object.keys(options)
-      // Get only options with value
-      .filter(optKey => !!(options as Record<string, unknown>)[optKey])
-      // to CMD option
-      .map(optKey => ({
-        cmdOptions: `--${toKebabCase(optKey)}`,
-        value: (options as Record<string, string | boolean | number>)[optKey],
-      }))
-      // push the command and the value to the array
-      .flatMap(cmdOptionValue => [
-        cmdOptionValue.cmdOptions,
-        cmdOptionValue.value.toString(),
-      ])
-  );
+  return Object.entries(options).flatMap(([optKey, value]) => {
+    if (
+      value === undefined ||
+      value === null ||
+      value === false ||
+      value === ''
+    ) {
+      return [];
+    }
+
+    const cmdOption = `--${toKebabCase(optKey)}`;
+
+    if (typeof value === 'boolean') {
+      return [cmdOption];
+    }
+
+    if (typeof value === 'string' || typeof value === 'number') {
+      return [cmdOption, String(value)];
+    }
+
+    return [];
+  });
 }

--- a/packages/ngx-deploy-npm/src/executors/deploy/schema.d.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/schema.d.ts
@@ -28,6 +28,18 @@ export interface DeployExecutorOptions {
    */
   dryRun?: boolean;
   /**
+   * When publishing from a supported cloud CI/CD system, the package will be publicly linked to where it was built and published from. Cannot be used with provenanceFile.
+   */
+  provenance?: boolean;
+  /**
+   * When publishing, the provenance bundle at the given path will be used. Cannot be used with provenance.
+   */
+  provenanceFile?: string;
+  /**
+   * If true, npm does not run scripts specified in package.json during publish.
+   */
+  ignoreScripts?: boolean;
+  /**
    * Check if the package version already exists before publishing
    */
   checkExisting?: 'error' | 'warning' | 'skip';

--- a/packages/ngx-deploy-npm/src/executors/deploy/schema.json
+++ b/packages/ngx-deploy-npm/src/executors/deploy/schema.json
@@ -37,6 +37,20 @@
       "description": "For testing: Run through without making any changes. Execute with --dry-run and nothing will happen.",
       "default": false
     },
+    "provenance": {
+      "type": "boolean",
+      "description": "When publishing from a supported cloud CI/CD system, the package will be publicly linked to where it was built and published from. Cannot be used with provenanceFile.",
+      "default": false
+    },
+    "provenanceFile": {
+      "type": "string",
+      "description": "When publishing, the provenance bundle at the given path will be used. Cannot be used with provenance."
+    },
+    "ignoreScripts": {
+      "type": "boolean",
+      "description": "If true, npm does not run scripts specified in package.json during publish.",
+      "default": false
+    },
     "checkExisting": {
       "type": "string",
       "description": "How to handle existing package versions: 'warning' to skip publishing with a warning, 'error' to abort publishing, 'skip' to skip publishing silently",

--- a/packages/ngx-deploy-npm/src/executors/deploy/utils/interfaces.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/utils/interfaces.ts
@@ -2,5 +2,12 @@ import { DeployExecutorOptions } from '../schema';
 
 export type NpmPublishOptions = Pick<
   DeployExecutorOptions,
-  'access' | 'tag' | 'otp' | 'dryRun' | 'registry'
+  | 'access'
+  | 'tag'
+  | 'otp'
+  | 'dryRun'
+  | 'registry'
+  | 'provenance'
+  | 'provenanceFile'
+  | 'ignoreScripts'
 >;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

The deploy executor only forwards a subset of `npm publish` flags (`access`, `tag`, `otp`, `dryRun`, `registry`). Common CI flags such as `--provenance`, `--provenance-file`, and `--ignore-scripts` are not available as deploy options.

Boolean flags are also forwarded with an explicit value (e.g. `--dry-run true`) rather than as flag-only arguments.

Issue Number: N/A

## What is the new behavior?

The deploy executor schema and engine now support three additional npm publish passthrough options:

- `provenance` → `--provenance` (supply-chain attestation in supported CI environments)
- `provenanceFile` → `--provenance-file <path>` (externally generated Sigstore bundle)
- `ignoreScripts` → `--ignore-scripts` (skip lifecycle scripts during publish)

`getOptionsStringArr` now emits flag-only arguments for boolean options and skips unset/false values.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- npm workspace flags (`--workspace`, `--workspaces`) were intentionally omitted — Nx orchestrates monorepo publishing via per-project deploy targets and `nx run-many` / `nx affected`.
- Adds unit tests for passthrough flags and `provenanceFile` forwarding.
- `provenance` requires GitHub Actions/GitLab CI + registry.npmjs.org; it cannot be tested against local Verdaccio.