### PR TITLE
fix(ngx-deploy-npm): apply packageVersion transiently during dry-run

### DIFF
--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
@@ -181,29 +181,81 @@ describe('engine', () => {
   });
 
   describe('Package.json Feature', () => {
-    const pJsonSetup = ({
-      version = '1.0.1-next0',
-      setPackageReturnValue = Promise.resolve(),
-      ...originalSetupOptions
-    }: {
+    type PJsonSetupOptions = {
       version?: string;
       setPackageReturnValue?: Promise<void>;
-    } & SetupOptions) => {
-      jest
-        .spyOn(setPackage, 'setPackageVersion')
-        .mockImplementation(() => setPackageReturnValue);
+      dryRun?: boolean;
+      mockPackageJson?: { name: string; version: string };
+    } & SetupOptions;
 
+    type PJsonSetupResult = ReturnType<typeof setup> & { version: string };
+
+    type PJsonDryRunSetupResult = PJsonSetupResult & {
+      originalContent: string;
+      getCurrentContent: () => string;
+    };
+
+    function pJsonSetup(
+      opts: PJsonSetupOptions & { dryRun: true }
+    ): PJsonDryRunSetupResult;
+    function pJsonSetup(opts?: PJsonSetupOptions): PJsonSetupResult;
+    function pJsonSetup({
+      version = '1.0.1-next0',
+      setPackageReturnValue = Promise.resolve(),
+      dryRun = false,
+      mockPackageJson = { name: '@test/package', version: '1.0.0' },
+      ...originalSetupOptions
+    }: PJsonSetupOptions = {}): PJsonSetupResult | PJsonDryRunSetupResult {
       if (!originalSetupOptions.options) {
         originalSetupOptions.options = { ...defaultOption };
       }
 
       originalSetupOptions.options.packageVersion = version;
 
+      if (dryRun) {
+        originalSetupOptions.options = {
+          ...originalSetupOptions.options,
+          access: npmAccess.public,
+          dryRun: true,
+          packageVersion: version,
+        };
+
+        let currentContent = JSON.stringify(mockPackageJson);
+        const originalContent = currentContent;
+
+        const baseSetup = setup({
+          ...originalSetupOptions,
+          mockPackageJson,
+        });
+
+        jest
+          .spyOn(fileUtils, 'readFileAsync')
+          .mockImplementation(() => Promise.resolve(currentContent));
+
+        jest
+          .spyOn(fileUtils, 'writeFileAsync')
+          .mockImplementation((_, data) => {
+            currentContent = data as string;
+            return Promise.resolve();
+          });
+
+        return {
+          ...baseSetup,
+          version,
+          originalContent,
+          getCurrentContent: () => currentContent,
+        };
+      }
+
+      jest
+        .spyOn(setPackage, 'setPackageVersion')
+        .mockImplementation(() => setPackageReturnValue);
+
       return {
         version,
         ...setup(originalSetupOptions),
       };
-    };
+    }
 
     it('should write the version of the sent on the package.json', async () => {
       const { absoluteDistFolderPath, version, options } = pJsonSetup({});
@@ -216,17 +268,44 @@ describe('engine', () => {
       );
     });
 
-    it('should not write the version of the sent on the package.json if is on dry-run mode', async () => {
-      const { absoluteDistFolderPath, options } = pJsonSetup({
-        options: {
-          access: npmAccess.public,
-          dryRun: true,
-        },
-      });
+    it('should apply packageVersion temporarily during dry-run and restore original package.json', async () => {
+      const {
+        absoluteDistFolderPath,
+        options,
+        originalContent,
+        getCurrentContent,
+      } = pJsonSetup({ dryRun: true });
 
       await engine.run(absoluteDistFolderPath, options);
 
-      expect(setPackage.setPackageVersion).not.toHaveBeenCalled();
+      expect(getCurrentContent()).toEqual(originalContent);
+    });
+
+    it('should restore original package.json during dry-run when publish fails', async () => {
+      const {
+        absoluteDistFolderPath,
+        options,
+        originalContent,
+        getCurrentContent,
+        loggerErrorSpy,
+      } = pJsonSetup({
+        dryRun: true,
+        logError: true,
+        spawnAsyncMock: (_mainProgram, programArgs) => {
+          if (programArgs?.[0] === 'publish') {
+            return Promise.reject(new Error('publish failed'));
+          }
+
+          return Promise.resolve();
+        },
+      });
+
+      await expect(() =>
+        engine.run(absoluteDistFolderPath, options)
+      ).rejects.toThrow('publish failed');
+
+      expect(loggerErrorSpy).toHaveBeenCalledWith('❌ An error occurred!');
+      expect(getCurrentContent()).toEqual(originalContent);
     });
   });
 
@@ -270,6 +349,50 @@ describe('engine', () => {
           mockPackageJson,
           spawnAsyncMock,
         }),
+      };
+    };
+
+    const versionCheckDryRunSetup = ({
+      packageVersion = '2.0.0',
+      mockPackageJson = defaultMockPackageJson,
+      npmViewResult = () => Promise.reject({ code: 'E404' }),
+      ...originalSetupOptions
+    }: {
+      packageVersion?: string;
+      mockPackageJson?: { name: string; version: string };
+      npmViewResult?: () => Promise<void>;
+    } & Omit<
+      Parameters<typeof versionCheckSetup>[0],
+      'mockPackageJson' | 'npmViewResult'
+    > = {}) => {
+      let currentContent = JSON.stringify(mockPackageJson);
+
+      const baseSetup = versionCheckSetup({
+        mockPackageJson,
+        npmViewResult,
+        ...originalSetupOptions,
+        options: {
+          ...defaultOption,
+          checkExisting: 'error',
+          dryRun: true,
+          packageVersion,
+          ...originalSetupOptions.options,
+        },
+      });
+
+      jest
+        .spyOn(fileUtils, 'readFileAsync')
+        .mockImplementation(() => Promise.resolve(currentContent));
+
+      jest.spyOn(fileUtils, 'writeFileAsync').mockImplementation((_, data) => {
+        currentContent = data as string;
+        return Promise.resolve();
+      });
+
+      return {
+        ...baseSetup,
+        packageVersion,
+        getCurrentContent: () => currentContent,
       };
     };
 
@@ -369,6 +492,27 @@ describe('engine', () => {
         'version',
       ]);
       expect(spawn.spawnAsync).not.toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['publish'])
+      );
+    });
+
+    it('should check packageVersion during dry-run instead of dist build version', async () => {
+      const {
+        absoluteDistFolderPath,
+        options,
+        mockPackageJson,
+        packageVersion,
+      } = versionCheckDryRunSetup({});
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(spawn.spawnAsync).toHaveBeenCalledWith('npm', [
+        'view',
+        `${mockPackageJson.name}@${packageVersion}`,
+        'version',
+      ]);
+      expect(spawn.spawnAsync).toHaveBeenCalledWith(
         'npm',
         expect.arrayContaining(['publish'])
       );

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
@@ -4,6 +4,7 @@ import * as path from 'node:path';
 
 import {
   setPackageVersion,
+  withTemporaryPackageVersion,
   NpmPublishOptions,
   spawnAsync,
   spawnAsyncMatchStdout,
@@ -97,20 +98,6 @@ function shouldRunExistingCheck(options: DeployExecutorOptions): boolean {
 function logDryRunBanner(options: DeployExecutorOptions): void {
   if (options.dryRun) {
     logger.info('Dry-run: The package is not going to be published');
-  }
-}
-
-async function applyPackageVersionIfNeeded(
-  distFolderPath: string,
-  options: DeployExecutorOptions
-): Promise<void> {
-  /*
-  Modifying the dist when the user is dry-run mode,
-  thanks to the Nx Cache could lead to leading to publishing and unexpected package version
-  when the option is removed
-  */
-  if (options.packageVersion && !options.dryRun) {
-    await setPackageVersion(distFolderPath, options.packageVersion);
   }
 }
 
@@ -211,13 +198,12 @@ async function logPublishSummary(
   logger.info('--------------------------------');
 }
 
-export async function run(
+async function runDeploy(
   distFolderPath: string,
   options: DeployExecutorOptions
-) {
+): Promise<void> {
   try {
     logDryRunBanner(options);
-    await applyPackageVersionIfNeeded(distFolderPath, options);
 
     const npmOptions = extractOnlyNPMOptions(options);
 
@@ -236,6 +222,26 @@ export async function run(
     logger.error('❌ An error occurred!');
     throw error;
   }
+}
+
+export async function run(
+  distFolderPath: string,
+  options: DeployExecutorOptions
+) {
+  if (options.packageVersion && options.dryRun) {
+    await withTemporaryPackageVersion(
+      distFolderPath,
+      options.packageVersion,
+      () => runDeploy(distFolderPath, options)
+    );
+    return;
+  }
+
+  if (options.packageVersion) {
+    await setPackageVersion(distFolderPath, options.packageVersion);
+  }
+
+  await runDeploy(distFolderPath, options);
 }
 
 /**

--- a/packages/ngx-deploy-npm/src/executors/deploy/utils/set-package-version.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/utils/set-package-version.spec.ts
@@ -1,5 +1,8 @@
 import * as fileUtils from '../../../utils';
-import { setPackageVersion } from './set-package-version';
+import {
+  setPackageVersion,
+  withTemporaryPackageVersion,
+} from './set-package-version';
 
 jest.mock('../../../utils', () => {
   return {
@@ -60,5 +63,89 @@ describe('setPackageVersion', () => {
     await setPackageVersion(dir, version);
 
     expect(written.value).toEqual(JSON.stringify(expectedPackage, null, 4));
+  });
+});
+
+describe('withTemporaryPackageVersion', () => {
+  function setupWithTemporaryPackageVersion(
+    opts: {
+      version?: string;
+      dir?: string;
+      packageJson?: Record<string, unknown>;
+      fn?: () => Promise<void>;
+      fnError?: Error;
+    } = {}
+  ) {
+    const {
+      version = '1.0.1-next0',
+      dir = 'some/random/dir',
+      packageJson = {
+        name: 'ngx-deploy-npm',
+        version: 'boilerPlate',
+        description: 'Publish your libraries to NPM with just one command',
+        main: 'index.js',
+      },
+      fn = () => Promise.resolve(),
+      fnError,
+    } = opts;
+
+    const originalContent = JSON.stringify(packageJson);
+    let currentContent = originalContent;
+    const writes: string[] = [];
+
+    jest
+      .spyOn(fileUtils, 'readFileAsync')
+      .mockImplementation(() => Promise.resolve(currentContent));
+
+    jest.spyOn(fileUtils, 'writeFileAsync').mockImplementation((_, data) => {
+      currentContent = data as string;
+      writes.push(currentContent);
+      return Promise.resolve();
+    });
+
+    const fnToRun = fnError === undefined ? fn : () => Promise.reject(fnError);
+
+    return {
+      dir,
+      version,
+      originalContent,
+      fnToRun,
+      getCurrentContent: () => currentContent,
+      writes,
+    };
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should apply packageVersion temporarily and restore the original content', async () => {
+    const {
+      dir,
+      version,
+      originalContent,
+      fnToRun,
+      getCurrentContent,
+      writes,
+    } = setupWithTemporaryPackageVersion();
+
+    await withTemporaryPackageVersion(dir, version, fnToRun);
+
+    expect(writes).toHaveLength(2);
+    expect(JSON.parse(writes[0]).version).toBe(version);
+    expect(getCurrentContent()).toEqual(originalContent);
+  });
+
+  it('should restore the original content when fn throws', async () => {
+    const { dir, version, originalContent, fnToRun, getCurrentContent } =
+      setupWithTemporaryPackageVersion({
+        fnError: new Error('callback failed'),
+      });
+
+    await expect(() =>
+      withTemporaryPackageVersion(dir, version, fnToRun)
+    ).rejects.toThrow('callback failed');
+
+    expect(getCurrentContent()).toEqual(originalContent);
   });
 });

--- a/packages/ngx-deploy-npm/src/executors/deploy/utils/set-package-version.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/utils/set-package-version.ts
@@ -17,3 +17,24 @@ export async function setPackageVersion(dir: string, packageVersion: string) {
     { encoding: 'utf8' }
   );
 }
+
+export async function withTemporaryPackageVersion(
+  dir: string,
+  packageVersion: string,
+  fn: () => Promise<void>
+): Promise<void> {
+  const packageJsonPath = path.join(dir, 'package.json');
+  const originalContent = await fileUtils.readFileAsync(packageJsonPath, {
+    encoding: 'utf8',
+  });
+
+  await setPackageVersion(dir, packageVersion);
+
+  try {
+    await fn();
+  } finally {
+    await fileUtils.writeFileAsync(packageJsonPath, originalContent, {
+      encoding: 'utf8',
+    });
+  }
+}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

When `dryRun` and `packageVersion` are used together, the executor skips writing the target version to `dist/package.json`. As a result:

- `checkExisting` evaluates the **build** version instead of the intended `packageVersion`, causing false duplicate-version errors during dry-run.
- `npm publish --dry-run`, tarball size, and the publish summary reflect the wrong version.

The previous guard avoided mutating dist during dry-run because a persisted change could survive an Nx cache hit and affect a later real publish.

Issue Number: N/A

## What is the new behavior?

- **Dry-run + `packageVersion`**: applies the version temporarily via `withTemporaryPackageVersion`, runs the full deploy flow, then restores the original `dist/package.json` in a `finally` block (including on error).
- **Real publish**: unchanged — permanently writes `packageVersion` to dist.

This keeps dry-run simulation accurate while guaranteeing dist is not left mutated after dry-run completes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

### Test plan

- [x] `npm exec nx test ngx-deploy-npm -- --testPathPattern="engine.spec|set-package-version.spec"`
- [x] `npm exec nx run ngx-deploy-npm-e2e:e2e` (optional)