### PR TITLE
ci: post release preview comments for fork PRs via workflow_run

### DIFF
--- a/.github/workflows/pr-release-preview-comment.yml
+++ b/.github/workflows/pr-release-preview-comment.yml
@@ -1,0 +1,97 @@
+name: PR Release Preview Comment
+
+on:
+  workflow_run:
+    workflows: ['PR Release Preview']
+    types: [completed]
+
+jobs:
+  post-comment:
+    name: Post release preview comment
+    runs-on: ubuntu-latest
+    if: >
+      github.event.workflow_run.event == 'pull_request' &&
+      github.event.workflow_run.conclusion != 'cancelled'
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: write
+    steps:
+      - name: Get PR number from head SHA
+        id: pr-info
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const headSha = context.payload.workflow_run.head_sha;
+            console.log(`Looking up PR for head SHA: ${headSha}`);
+
+            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              commit_sha: headSha,
+            });
+
+            if (prs.length === 0) {
+              throw new Error(`No PR found for commit ${headSha}`);
+            }
+
+            const prNumber = prs[0].number;
+            console.log(`Found PR #${prNumber}`);
+            core.setOutput('pr-number', prNumber);
+
+      - name: Download release preview comment
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const artifactName = 'release-preview-comment';
+            console.log(`Looking for artifact: ${artifactName}`);
+
+            const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              run_id: context.payload.workflow_run.id,
+            });
+            console.log(
+              'Available artifacts:',
+              allArtifacts.data.artifacts.map((artifact) => artifact.name)
+            );
+
+            const matchArtifact = allArtifacts.data.artifacts.find(
+              (artifact) => artifact.name === artifactName
+            );
+
+            if (!matchArtifact) {
+              throw new Error(`Artifact "${artifactName}" not found!`);
+            }
+
+            const download = await github.rest.actions.downloadArtifact({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              artifact_id: matchArtifact.id,
+              archive_format: 'zip',
+            });
+
+            const fs = require('fs');
+            fs.writeFileSync(
+              `${process.env.GITHUB_WORKSPACE}/${artifactName}.zip`,
+              Buffer.from(download.data)
+            );
+
+      - name: Extract release preview comment
+        run: unzip release-preview-comment.zip
+
+      - name: Find existing preview comment
+        uses: peter-evans/find-comment@v4
+        id: find-comment
+        with:
+          issue-number: ${{ steps.pr-info.outputs.pr-number }}
+          comment-author: github-actions[bot]
+          body-includes: ngx-deploy-npm-release-preview
+
+      - name: Create or update preview comment
+        uses: peter-evans/create-or-update-comment@v5
+        with:
+          comment-id: ${{ steps.find-comment.outputs.comment-id }}
+          issue-number: ${{ steps.pr-info.outputs.pr-number }}
+          edit-mode: replace
+          body-path: comment.md

--- a/.github/workflows/pr-release-preview.yml
+++ b/.github/workflows/pr-release-preview.yml
@@ -10,7 +10,6 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
-      pull-requests: write
     steps:
       - uses: actions/checkout@v6
       - uses: ./.github/actions/setup
@@ -34,23 +33,13 @@ jobs:
           COMMITLINT_OK: ${{ steps.commitlint.outputs.ok == 'true' && '1' || '0' }}
         run: npx ts-node --transpile-only -O '{"module":"commonjs"}' tools/ci/pr-release-preview.ts
 
-      - name: Find existing preview comment
+      - name: Upload release preview comment
         if: always() && steps.preview.outcome != 'skipped'
-        uses: peter-evans/find-comment@v4
-        id: find-comment
+        uses: actions/upload-artifact@v7
         with:
-          issue-number: ${{ github.event.pull_request.number }}
-          comment-author: github-actions[bot]
-          body-includes: ngx-deploy-npm-release-preview
-
-      - name: Create or update preview comment
-        if: always() && steps.preview.outcome != 'skipped'
-        uses: peter-evans/create-or-update-comment@v5
-        with:
-          comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.pull_request.number }}
-          edit-mode: replace
-          body-path: comment.md
+          name: release-preview-comment
+          path: comment.md
+          retention-days: 1
 
       - name: Enforce valid PR title
         if: steps.commitlint.outputs.ok != 'true'


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

The PR Release Preview workflow posts the release preview bot comment directly from the `pull_request` job. On contributor PRs from forks, GitHub grants a read-only `GITHUB_TOKEN`, so the comment step fails with **403 Resource not accessible by integration** even when commitlint and semver preview succeed.

Issue Number: N/A

## What is the new behavior?

- **PR Release Preview** (`pr-release-preview.yml`) runs commitlint and semver dry-run on the PR code with read-only permissions, uploads `comment.md` as an artifact, and remains the merge-blocking check.
- **PR Release Preview Comment** (`pr-release-preview-comment.yml`) runs on `workflow_run` completion (same pattern as Sonar for PRs), downloads the artifact in the base repo context, resolves the PR number from the head SHA, and posts or updates the bot comment with write permissions.

Contributor fork PRs can pass Release preview and receive the preview comment once this workflow exists on `main`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Follow-up to #741. Fixes the Release preview failure seen on contributor PR #707.

## Test plan

- [ ] Merge to `main`, then re-run Release preview on a fork PR and confirm the bot comment appears
- [ ] Confirm same-repo PRs still get the release preview comment
- [ ] Confirm invalid PR titles still fail Release preview and the comment includes commitlint output