### PR TITLE
ci: resolve release preview PR from artifact metadata

### DIFF
--- a/.github/workflows/pr-release-preview-comment.yml
+++ b/.github/workflows/pr-release-preview-comment.yml
@@ -17,39 +17,20 @@ jobs:
       contents: read
       pull-requests: write
     steps:
-      - name: Get PR number from head SHA
-        id: pr-info
-        uses: actions/github-script@v7
-        with:
-          script: |
-            const headSha = context.payload.workflow_run.head_sha;
-            console.log(`Looking up PR for head SHA: ${headSha}`);
-
-            const { data: prs } = await github.rest.repos.listPullRequestsAssociatedWithCommit({
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              commit_sha: headSha,
-            });
-
-            if (prs.length === 0) {
-              throw new Error(`No PR found for commit ${headSha}`);
-            }
-
-            const prNumber = prs[0].number;
-            console.log(`Found PR #${prNumber}`);
-            core.setOutput('pr-number', prNumber);
-
       - name: Download release preview comment
         uses: actions/github-script@v7
         with:
           script: |
             const artifactName = 'release-preview-comment';
-            console.log(`Looking for artifact: ${artifactName}`);
+            const previewRunId = context.payload.workflow_run.id;
+            console.log(
+              `Downloading artifact from PR Release Preview run ${previewRunId} (head ${context.payload.workflow_run.head_sha})`
+            );
 
             const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
               owner: context.repo.owner,
               repo: context.repo.repo,
-              run_id: context.payload.workflow_run.id,
+              run_id: previewRunId,
             });
             console.log(
               'Available artifacts:',
@@ -61,7 +42,7 @@ jobs:
             );
 
             if (!matchArtifact) {
-              throw new Error(`Artifact "${artifactName}" not found!`);
+              throw new Error(`Artifact "${artifactName}" not found on run ${previewRunId}`);
             }
 
             const download = await github.rest.actions.downloadArtifact({
@@ -79,6 +60,49 @@ jobs:
 
       - name: Extract release preview comment
         run: unzip release-preview-comment.zip
+
+      - name: Resolve PR number
+        id: pr-info
+        uses: actions/github-script@v7
+        env:
+          WORKFLOW_RUN: ${{ toJson(github.event.workflow_run) }}
+        with:
+          script: |
+            const fs = require('fs');
+            const workflowRun = JSON.parse(process.env.WORKFLOW_RUN);
+
+            if (fs.existsSync('pr-number.txt')) {
+              const prNumber = fs.readFileSync('pr-number.txt', 'utf8').trim();
+              console.log(`Resolved PR #${prNumber} from artifact`);
+              core.setOutput('pr-number', prNumber);
+              return;
+            }
+
+            const linkedPrs = workflowRun.pull_requests ?? [];
+            if (linkedPrs.length > 0) {
+              const prNumber = linkedPrs[0].number;
+              console.log(`Resolved PR #${prNumber} from workflow_run.pull_requests`);
+              core.setOutput('pr-number', prNumber);
+              return;
+            }
+
+            const headSha = workflowRun.head_sha;
+            console.log(`Resolving PR from head SHA: ${headSha}`);
+            const { data: prs } =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                commit_sha: headSha,
+              });
+
+            const openPr = prs.find((pr) => pr.state === 'open');
+            const pr = openPr ?? prs[0];
+            if (!pr) {
+              throw new Error(`No PR found for commit ${headSha}`);
+            }
+
+            console.log(`Resolved PR #${pr.number} from commit association (${pr.state})`);
+            core.setOutput('pr-number', pr.number);
 
       - name: Find existing preview comment
         uses: peter-evans/find-comment@v4

--- a/.github/workflows/pr-release-preview.yml
+++ b/.github/workflows/pr-release-preview.yml
@@ -33,12 +33,18 @@ jobs:
           COMMITLINT_OK: ${{ steps.commitlint.outputs.ok == 'true' && '1' || '0' }}
         run: npx ts-node --transpile-only -O '{"module":"commonjs"}' tools/ci/pr-release-preview.ts
 
+      - name: Save PR metadata
+        if: always() && steps.preview.outcome != 'skipped'
+        run: echo '${{ github.event.pull_request.number }}' > pr-number.txt
+
       - name: Upload release preview comment
         if: always() && steps.preview.outcome != 'skipped'
         uses: actions/upload-artifact@v7
         with:
           name: release-preview-comment
-          path: comment.md
+          path: |
+            comment.md
+            pr-number.txt
           retention-days: 1
 
       - name: Enforce valid PR title


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

The comment workflow resolves the target PR via `listPullRequestsAssociatedWithCommit` on `workflow_run.head_sha`. That is fragile: merge commits can map to the wrong closed PR, and the comment workflow run itself always displays `main`'s SHA (`f7e190f`), which is easy to misread as posting to the wrong commit.

Issue Number: N/A

## What is the new behavior?

- Preview job stores `pr-number.txt` alongside `comment.md` in the artifact.
- Comment job resolves PR in order: artifact → `workflow_run.pull_requests` → open PR from head SHA.
- Logs include the triggering preview run id and head SHA for easier debugging.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Follow-up to #753. Investigated #752 where the comment workflow run showed `f7e190f` but the preview run used `0402bab`.

## Test plan

- [ ] Re-run Release preview on an open PR and confirm the bot comment is created/updated on that PR
- [ ] Confirm fork PRs still receive comments after merge to `main`