### PR TITLE
ci: resolve release preview PR from workflow_run metadata

### DIFF
--- a/.github/workflows/pr-release-preview-comment.yml
+++ b/.github/workflows/pr-release-preview-comment.yml
@@ -61,54 +61,11 @@ jobs:
       - name: Extract release preview comment
         run: unzip release-preview-comment.zip
 
-      - name: Resolve PR number
-        id: pr-info
-        uses: actions/github-script@v7
-        env:
-          WORKFLOW_RUN: ${{ toJson(github.event.workflow_run) }}
-        with:
-          script: |
-            const fs = require('fs');
-            const workflowRun = JSON.parse(process.env.WORKFLOW_RUN);
-
-            if (fs.existsSync('pr-number.txt')) {
-              const prNumber = fs.readFileSync('pr-number.txt', 'utf8').trim();
-              console.log(`Resolved PR #${prNumber} from artifact`);
-              core.setOutput('pr-number', prNumber);
-              return;
-            }
-
-            const linkedPrs = workflowRun.pull_requests ?? [];
-            if (linkedPrs.length > 0) {
-              const prNumber = linkedPrs[0].number;
-              console.log(`Resolved PR #${prNumber} from workflow_run.pull_requests`);
-              core.setOutput('pr-number', prNumber);
-              return;
-            }
-
-            const headSha = workflowRun.head_sha;
-            console.log(`Resolving PR from head SHA: ${headSha}`);
-            const { data: prs } =
-              await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                owner: context.repo.owner,
-                repo: context.repo.repo,
-                commit_sha: headSha,
-              });
-
-            const openPr = prs.find((pr) => pr.state === 'open');
-            const pr = openPr ?? prs[0];
-            if (!pr) {
-              throw new Error(`No PR found for commit ${headSha}`);
-            }
-
-            console.log(`Resolved PR #${pr.number} from commit association (${pr.state})`);
-            core.setOutput('pr-number', pr.number);
-
       - name: Find existing preview comment
         uses: peter-evans/find-comment@v4
         id: find-comment
         with:
-          issue-number: ${{ steps.pr-info.outputs.pr-number }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           comment-author: github-actions[bot]
           body-includes: ngx-deploy-npm-release-preview
 
@@ -116,6 +73,6 @@ jobs:
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ steps.pr-info.outputs.pr-number }}
+          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
           edit-mode: replace
           body-path: comment.md

--- a/.github/workflows/pr-release-preview.yml
+++ b/.github/workflows/pr-release-preview.yml
@@ -33,18 +33,12 @@ jobs:
           COMMITLINT_OK: ${{ steps.commitlint.outputs.ok == 'true' && '1' || '0' }}
         run: npx ts-node --transpile-only -O '{"module":"commonjs"}' tools/ci/pr-release-preview.ts
 
-      - name: Save PR metadata
-        if: always() && steps.preview.outcome != 'skipped'
-        run: echo '${{ github.event.pull_request.number }}' > pr-number.txt
-
       - name: Upload release preview comment
         if: always() && steps.preview.outcome != 'skipped'
         uses: actions/upload-artifact@v7
         with:
           name: release-preview-comment
-          path: |
-            comment.md
-            pr-number.txt
+          path: comment.md
           retention-days: 1
 
       - name: Enforce valid PR title


### PR DESCRIPTION
Superseded by #757, which resolves fork PR context via `pulls.list` fallback instead of relying on `workflow_run.pull_requests[0]` alone.