### PR TITLE
ci: resolve fork PR context in workflow_run follow-ups

### DIFF
--- a/.github/actions/resolve-pr-from-workflow-run/action.yml
+++ b/.github/actions/resolve-pr-from-workflow-run/action.yml
@@ -1,0 +1,56 @@
+name: Resolve PR from workflow run
+description: Resolve PR number and refs from a workflow_run event (same-repo and fork PRs)
+outputs:
+  pr-number:
+    description: Pull request number
+    value: ${{ steps.resolve.outputs.pr-number }}
+  pr-head-ref:
+    description: Pull request head branch ref
+    value: ${{ steps.resolve.outputs.pr-head-ref }}
+  pr-base-ref:
+    description: Pull request base branch ref
+    value: ${{ steps.resolve.outputs.pr-base-ref }}
+runs:
+  using: composite
+  steps:
+    - name: Resolve PR
+      id: resolve
+      uses: actions/github-script@v7
+      with:
+        script: |
+          const workflowRun = context.payload.workflow_run;
+          const linkedPr = workflowRun.pull_requests?.[0];
+
+          if (linkedPr?.number) {
+            core.setOutput('pr-number', String(linkedPr.number));
+            core.setOutput('pr-head-ref', linkedPr.head?.ref ?? workflowRun.head_branch);
+            core.setOutput('pr-base-ref', linkedPr.base?.ref ?? 'main');
+            console.log(`Resolved PR #${linkedPr.number} from workflow_run.pull_requests`);
+            return;
+          }
+
+          const owner = workflowRun.head_repository?.owner?.login;
+          const branch = workflowRun.head_branch;
+          if (!owner || !branch) {
+            throw new Error('Missing head_repository or head_branch on workflow_run');
+          }
+
+          const head = `${owner}:${branch}`;
+          console.log(`Looking up open PR for head ${head}`);
+          const { data: prs } = await github.rest.pulls.list({
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            head,
+            state: 'open',
+          });
+
+          const headSha = workflowRun.head_sha;
+          const pr = prs.find((item) => item.head?.sha === headSha) ?? prs[0];
+          if (!pr) {
+            throw new Error(`No open PR found for head ${head}`);
+          }
+
+          core.setOutput('pr-number', String(pr.number));
+          core.setOutput('pr-head-ref', pr.head.ref);
+          core.setOutput('pr-base-ref', pr.base.ref);
+          console.log(`Resolved PR #${pr.number} from pulls.list (${head})`);

--- a/.github/workflows/pr-release-preview-comment.yml
+++ b/.github/workflows/pr-release-preview-comment.yml
@@ -17,6 +17,8 @@ jobs:
       contents: read
       pull-requests: write
     steps:
+      - uses: actions/checkout@v6
+
       - name: Download release preview comment
         uses: actions/github-script@v7
         with:
@@ -61,11 +63,15 @@ jobs:
       - name: Extract release preview comment
         run: unzip release-preview-comment.zip
 
+      - name: Resolve PR
+        id: resolve-pr
+        uses: ./.github/actions/resolve-pr-from-workflow-run
+
       - name: Find existing preview comment
         uses: peter-evans/find-comment@v4
         id: find-comment
         with:
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ steps.resolve-pr.outputs.pr-number }}
           comment-author: github-actions[bot]
           body-includes: ngx-deploy-npm-release-preview
 
@@ -73,6 +79,6 @@ jobs:
         uses: peter-evans/create-or-update-comment@v5
         with:
           comment-id: ${{ steps.find-comment.outputs.comment-id }}
-          issue-number: ${{ github.event.workflow_run.pull_requests[0].number }}
+          issue-number: ${{ steps.resolve-pr.outputs.pr-number }}
           edit-mode: replace
           body-path: comment.md

--- a/.github/workflows/sonar-pr.yml
+++ b/.github/workflows/sonar-pr.yml
@@ -9,76 +9,70 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     if: github.event.workflow_run.conclusion == 'success'
+    permissions:
+      actions: read
+      contents: read
+      pull-requests: read
     steps:
+      - uses: actions/checkout@v6
+
+      - name: Resolve PR
+        id: resolve-pr
+        uses: ./.github/actions/resolve-pr-from-workflow-run
+
       - uses: actions/checkout@v6
         with:
           repository: ${{ github.event.workflow_run.head_repository.full_name }}
           ref: ${{ github.event.workflow_run.head_branch }}
           fetch-depth: 0
 
-      - name: Debug Workflow Info
-        run: |
-          echo "Workflow Run ID: ${{ github.event.workflow_run.id }}"
-          echo "Workflow Head SHA: ${{ github.event.workflow_run.head_sha }}"
-          echo "Current SHA: ${{ github.sha }}"
-          echo "Head Branch: ${{ github.event.workflow_run.head_branch }}"
-          echo "Repository: ${{ github.event.workflow_run.head_repository.full_name }}"
-
-          # Output raw context for additional details
-          echo "=== Raw Context ==="
-          echo "Workflow Head SHA: ${{ github.event.workflow_run }}"
-
-      - name: 'Raw Context'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            JSON.stringify(${{ github.event.workflow_run }}, null, 2)
-
-      # Download reports
-      - name: 'Download reports'
-        uses: actions/github-script@v6
+      - name: Download reports
+        uses: actions/github-script@v7
         with:
           script: |
             async function downloadArtifact(artifactName) {
               console.log(`Looking for artifact: ${artifactName}`);
-              let allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              const allArtifacts = await github.rest.actions.listWorkflowRunArtifacts({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 run_id: context.payload.workflow_run.id,
               });
-              console.log('Available artifacts:', allArtifacts.data.artifacts.map(a => a.name));
+              console.log(
+                'Available artifacts:',
+                allArtifacts.data.artifacts.map((artifact) => artifact.name)
+              );
 
-              let matchArtifact = allArtifacts.data.artifacts.find((artifact) => {
-                return artifact.name === artifactName;
-              });
+              const matchArtifact = allArtifacts.data.artifacts.find(
+                (artifact) => artifact.name === artifactName
+              );
 
               if (!matchArtifact) {
                 throw new Error(`Artifact "${artifactName}" not found!`);
               }
 
-              let download = await github.rest.actions.downloadArtifact({
+              const download = await github.rest.actions.downloadArtifact({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 artifact_id: matchArtifact.id,
                 archive_format: 'zip',
               });
 
-              let fs = require('fs');
-              fs.writeFileSync(`${process.env.GITHUB_WORKSPACE}/${artifactName}.zip`, Buffer.from(download.data));
-              return artifactName;
+              const fs = require('fs');
+              fs.writeFileSync(
+                `${process.env.GITHUB_WORKSPACE}/${artifactName}.zip`,
+                Buffer.from(download.data)
+              );
             }
 
-            // Download both artifacts
             await Promise.all([
               downloadArtifact('ngx-deploy-npm-coverage-report'),
-              downloadArtifact('lint-report')
+              downloadArtifact('lint-report'),
             ]);
-      - name: 'Extract reports'
+
+      - name: Extract reports
         run: |
-          # Extract coverage report
           mkdir -p coverage/packages/ngx-deploy-npm
           unzip ngx-deploy-npm-coverage-report.zip -d coverage/packages/ngx-deploy-npm
-          # Extract lint report
           mkdir -p reports
           unzip lint-report.zip -d reports
 
@@ -90,6 +84,6 @@ jobs:
         with:
           args: >
             -Dsonar.scm.revision=${{ github.event.workflow_run.head_sha }}
-            -Dsonar.pullrequest.key=${{ github.event.workflow_run.pull_requests[0].number }}
-            -Dsonar.pullrequest.branch=${{ github.event.workflow_run.pull_requests[0].head.ref }}
-            -Dsonar.pullrequest.base=${{ github.event.workflow_run.pull_requests[0].base.ref }}
+            -Dsonar.pullrequest.key=${{ steps.resolve-pr.outputs.pr-number }}
+            -Dsonar.pullrequest.branch=${{ steps.resolve-pr.outputs.pr-head-ref }}
+            -Dsonar.pullrequest.base=${{ steps.resolve-pr.outputs.pr-base-ref }}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

Fork PRs leave `workflow_run.pull_requests` empty for security. Follow-up workflows (release preview comment, Sonar) use `pull_requests[0].number`, which is undefined for contributors opening PRs from forks — causing comment posting to fail with 404 and Sonar to miss PR analysis.

Issue Number: N/A

## What is the new behavior?

- New composite action `.github/actions/resolve-pr-from-workflow-run` resolves PR context from `workflow_run`:
  1. `pull_requests[0]` for same-repo PRs
  2. `pulls.list({ head: owner:branch })` for fork PRs
- Release preview comment and Sonar workflows use the action outputs instead of hardcoded `pull_requests[0]`.
- Removed temporary Sonar debug steps.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Supersedes #756. Fixes contributor PR #707 release preview comment and Sonar follow-ups.

## Test plan

- [ ] Merge to `main`, then re-run Release preview on fork PR #707 — bot comment should appear
- [ ] Confirm Sonar workflow triggers after PRs completes on #707
- [ ] Confirm same-repo PRs (e.g. #752) still work via fast path