### PR TITLE
ci: create GitHub release after pushing version tags

### DIFF
--- a/.github/workflows/publishment.yml
+++ b/.github/workflows/publishment.yml
@@ -63,8 +63,6 @@ jobs:
       # publisher on npmjs.com for workflow publishment.yml (see contributors doc).
       - name: Version and Publishment
         run: npx nx version ngx-deploy-npm
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Tag last-release
         run: git tag --force last-release
@@ -76,3 +74,8 @@ jobs:
           branch: ${{ github.ref }}
           force: true
           tags: true
+
+      - name: Create GitHub Release
+        run: npx nx github ngx-deploy-npm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/ngx-deploy-npm/project.json
+++ b/packages/ngx-deploy-npm/project.json
@@ -90,7 +90,7 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "postTargets": ["build", "github", "deploy"]
+        "postTargets": ["build", "deploy"]
       }
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

After #759, the publishment workflow runs `@jscutlery/semver:github` as a `postTarget` of `nx version`, which creates the GitHub release before version tags are pushed to the remote. That ordering can cause `gh release create` to run against tags that only exist locally at that point.

Issue Number: #244

## What is the new behavior?

The `github` target is removed from the semver `postTargets` chain. The publishment workflow now runs `npx nx github ngx-deploy-npm` in a dedicated step after `ad-m/github-push-action` pushes commits and tags, with `GITHUB_TOKEN` scoped to that step.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Follow-up to #759. Related to #244.