### PR TITLE
ci: run GitHub release via semver postTarget

### DIFF
--- a/.github/workflows/publishment.yml
+++ b/.github/workflows/publishment.yml
@@ -63,19 +63,16 @@ jobs:
       # publisher on npmjs.com for workflow publishment.yml (see contributors doc).
       - name: Version and Publishment
         run: npx nx version ngx-deploy-npm
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_BOT_TOKEN }}
 
       - name: Tag last-release
         run: git tag --force last-release
 
-      - name: Push changes
+      - name: Push Tag last-release
         uses: ad-m/github-push-action@master
         with:
           github_token: ${{ secrets.GIT_BOT_TOKEN }}
           branch: ${{ github.ref }}
           force: true
           tags: true
-
-      - name: Create GitHub Release
-        run: npx nx github ngx-deploy-npm
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/packages/ngx-deploy-npm/project.json
+++ b/packages/ngx-deploy-npm/project.json
@@ -90,7 +90,9 @@
     "version": {
       "executor": "@jscutlery/semver:version",
       "options": {
-        "postTargets": ["build", "deploy"]
+        "push": true,
+        "noVerify": true,
+        "postTargets": ["build", "deploy", "github"]
       }
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

Publishment runs `npx nx github ngx-deploy-npm` as a separate workflow step after `ad-m/github-push-action`. The `github` target options use `{tag}` and `{notes}`, but those placeholders are only interpolated when `github` runs as a `version` postTarget. The standalone step passed literal `{tag}` to `gh release create`, producing a broken release (e.g. tag name `{tag}`).

Issue Number: N/A (follow-up to #761 / #244)

## What is the new behavior?

- Add `github` back to the `version` postTargets with `push: true` and `noVerify: true` so semver interpolates `{tag}` / `{notes}` and runs `gh release create` during `nx version`.
- Pass `GITHUB_BOT_TOKEN` as `GITHUB_TOKEN` on the version step for `gh`.
- Remove the redundant "Create GitHub Release" workflow step.
- Keep `ad-m/github-push-action` after tagging `last-release` for force push of branch and tags to protected `main`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- Ensure repo secret `GITHUB_BOT_TOKEN` (fine-grained PAT) is configured with **Contents: Read and write** and the bot user is on the `main` branch protection bypass list.
- `GIT_BOT_TOKEN` remains used for checkout and `ad-m/github-push-action`.

## Test plan

- [ ] Merge and run publishment on `main` (or dry-run `npx nx version ngx-deploy-npm --dry-run` on a branch).
- [ ] Confirm the GitHub release uses the real tag (e.g. `ngx-deploy-npm-X.Y.Z`) and changelog notes, not `{tag}`.
- [ ] Confirm npm publish and git push to `main` still succeed.