### PR TITLE
feat(ngx-deploy-npm): add checkPublishReady pre-publish validation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,8 @@ reports/*
 
 # End of https://www.toptal.com/developers/gitignore/api/sonarqube
 
+.verdaccio/htpasswd
+
 .env
 .cursor/rules/nx-rules.mdc
 .github/instructions/nx.instructions.md

--- a/.verdaccio/config.yml
+++ b/.verdaccio/config.yml
@@ -1,6 +1,11 @@
 # path to a directory with all packages
 storage: ../tmp/local-registry/storage
 
+auth:
+  htpasswd:
+    file: ./htpasswd
+    max_users: 1000
+
 # a list of other known repositories we can talk to
 uplinks:
   npmjs:

--- a/README.md
+++ b/README.md
@@ -355,6 +355,37 @@ If it exists and `--check-existing=skip`, it will skip the publishing silently (
 When set, the duplicate version check only runs when publishing to a non-`latest` tag.
 Publishing with the default `latest` tag (or without `--tag`) skips the check even if `--check-existing` is set.
 
+#### `--check-publish-ready`
+
+- **optional**
+- Values: `probe` | `publish`
+- Example:
+  - `nx deploy my-lib --check-publish-ready=probe`
+  - `nx deploy my-lib --check-publish-ready=publish`
+
+Pre-publish validation **before** `checkExisting` and `npm publish`:
+
+| Step             | What it checks                                                                                                                                                                                                            |
+| ---------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| 1. Static        | Dist folder exists; `package.json` is valid; `name` and `version` are set; entry files (`main`, `module`, `types`, `typings`, `exports`) exist under dist; warns if `description`, `license`, or `repository` are missing |
+| 2. Auth          | `npm whoami` against the configured registry (clear error if not authenticated)                                                                                                                                           |
+| 3. Publish probe | `npm publish --dry-run` with a disposable version (`{version}-verify.{timestamp}` and dist-tag `verify`)                                                                                                                  |
+
+| Mode      | Typical use            | After validation                                                |
+| --------- | ---------------------- | --------------------------------------------------------------- |
+| `probe`   | Pre-bump CI verify job | Exit (no publish). Use when the dist version is not bumped yet. |
+| `publish` | Release / real publish | Continue to `checkExisting` (if set) and `npm publish`.         |
+
+**If you also pass deploy `--dry-run`:** that flag is independent of `--check-publish-ready`. Both can be used together. The executor logs a warning and runs **two** `npm publish --dry-run` calls: first with a disposable probe version, then with the version in dist `package.json`. The second dry-run may fail if that version is already on the registry.
+
+Examples:
+
+- **Pre-bump verify (no upload):** `nx build my-lib && nx deploy my-lib --check-publish-ready=probe`
+- **Release gate:** `nx deploy my-lib --check-publish-ready=publish`
+- **Probe + deploy dry-run (two dry-runs):** `nx deploy my-lib --check-publish-ready=probe --dry-run`
+
+Complements [`--check-existing`](#--check-existing); does not replace it.
+
 #### `--package-version`
 
 - **optional**

--- a/packages/ngx-deploy-npm-e2e/src/check-existing.spec.ts
+++ b/packages/ngx-deploy-npm-e2e/src/check-existing.spec.ts
@@ -1,35 +1,7 @@
 import { uniq } from '@nx/plugin/testing';
-import { e2eTestTimeout, setup } from './utils';
+import { deployCommand, E2E_REGISTRY, e2eTestTimeout, setup } from './utils';
 
 describe('checkExisting and checkTag', () => {
-  const registry = 'http://localhost:4873';
-
-  function deployCommand(
-    libName: string,
-    {
-      packageVersion = '0.0.0',
-      tag,
-      checkExisting,
-      checkTag,
-    }: {
-      packageVersion?: string;
-      tag?: string;
-      checkExisting?: 'error' | 'skip';
-      checkTag?: boolean;
-    } = {}
-  ) {
-    return [
-      `npx nx deploy ${libName}`,
-      `--registry=${registry}`,
-      `--packageVersion=${packageVersion}`,
-      tag ? `--tag="${tag}"` : '',
-      checkExisting ? `--checkExisting="${checkExisting}"` : '',
-      checkTag ? '--checkTag' : '',
-    ]
-      .filter(Boolean)
-      .join(' ');
-  }
-
   it(
     'should honor checkExisting skip and checkTag when publishing',
     async () => {
@@ -38,11 +10,17 @@ describe('checkExisting and checkTag', () => {
       ]);
       const [lib] = processedLibs;
 
-      executeCommand(deployCommand(lib.name, { tag: 'e2e' }));
+      executeCommand(
+        deployCommand(lib.name, { tag: 'e2e', packageVersion: '0.0.0' })
+      );
 
       expect(() => {
         executeCommand(
-          deployCommand(lib.name, { tag: 'e2e', checkExisting: 'skip' })
+          deployCommand(lib.name, {
+            tag: 'e2e',
+            packageVersion: '0.0.0',
+            checkExisting: 'skip',
+          })
         );
       }).not.toThrow();
 
@@ -50,6 +28,7 @@ describe('checkExisting and checkTag', () => {
         executeCommand(
           deployCommand(lib.name, {
             tag: 'e2e',
+            packageVersion: '0.0.0',
             checkExisting: 'error',
             checkTag: true,
           })
@@ -68,7 +47,7 @@ describe('checkExisting and checkTag', () => {
 
       expect(() => {
         executeCommand(
-          `npm view ${lib.npmPackageName}@0.0.1 --registry=${registry}`
+          `npm view ${lib.npmPackageName}@0.0.1 --registry=${E2E_REGISTRY}`
         );
       }).not.toThrow();
 

--- a/packages/ngx-deploy-npm-e2e/src/check-publish-ready.spec.ts
+++ b/packages/ngx-deploy-npm-e2e/src/check-publish-ready.spec.ts
@@ -1,0 +1,61 @@
+import { uniq } from '@nx/plugin/testing';
+import { deployCommand, E2E_REGISTRY, e2eTestTimeout, setup } from './utils';
+
+describe('checkPublishReady', () => {
+  it(
+    'should validate with probe on an already-published version, fail on missing dist, and publish after publish mode',
+    async () => {
+      const { processedLibs, tearDown, executeCommand } = await setup([
+        { name: uniq('check-publish-ready'), generator: 'minimal' },
+      ]);
+      const [lib] = processedLibs;
+
+      executeCommand(
+        deployCommand(lib.name, {
+          checkPublishReady: 'publish',
+          packageVersion: '0.0.0',
+          tag: 'e2e',
+        })
+      );
+
+      const probeOutput = executeCommand(
+        deployCommand(lib.name, { checkPublishReady: 'probe' })
+      );
+
+      expect(probeOutput).toMatch(/checkPublishReady=probe completed/);
+      expect(probeOutput).toMatch(/Skipping publish/);
+
+      expect(() => {
+        executeCommand(
+          `npm view ${lib.npmPackageName}@0.0.1 --registry=${E2E_REGISTRY}`
+        );
+      }).toThrow();
+
+      expect(() => {
+        executeCommand(
+          deployCommand(lib.name, {
+            checkPublishReady: 'probe',
+            distFolderPath: 'dist/does-not-exist',
+          })
+        );
+      }).toThrow(/Publish dist folder not found/);
+
+      executeCommand(
+        deployCommand(lib.name, {
+          checkPublishReady: 'publish',
+          packageVersion: '0.0.1',
+          tag: 'e2e',
+        })
+      );
+
+      expect(() => {
+        executeCommand(
+          `npm view ${lib.npmPackageName}@0.0.1 --registry=${E2E_REGISTRY}`
+        );
+      }).not.toThrow();
+
+      return tearDown();
+    },
+    e2eTestTimeout()
+  );
+});

--- a/packages/ngx-deploy-npm-e2e/src/publish-minimal-lib.smoke.spec.ts
+++ b/packages/ngx-deploy-npm-e2e/src/publish-minimal-lib.smoke.spec.ts
@@ -1,5 +1,5 @@
 import { uniq } from '@nx/plugin/testing';
-import { e2eTestTimeout, setup } from './utils';
+import { deployCommand, e2eTestTimeout, setup } from './utils';
 
 describe('Minimal Project', () => {
   it(
@@ -11,7 +11,10 @@ describe('Minimal Project', () => {
       const [uniqLibName] = processedLibs;
 
       executeCommand(
-        `npx nx deploy ${uniqLibName.name} --tag="e2e" --registry=http://localhost:4873 --packageVersion=0.0.0`
+        deployCommand(uniqLibName.name, {
+          tag: 'e2e',
+          packageVersion: '0.0.0',
+        })
       );
 
       expect(() => {

--- a/packages/ngx-deploy-npm-e2e/src/publish.spec.ts
+++ b/packages/ngx-deploy-npm-e2e/src/publish.spec.ts
@@ -1,5 +1,10 @@
 import { uniq } from '@nx/plugin/testing';
-import { e2eTestTimeout, e2eTestTimeoutExtended, setup } from './utils';
+import {
+  deployCommand,
+  e2eTestTimeout,
+  e2eTestTimeoutExtended,
+  setup,
+} from './utils';
 
 describe('Publish', () => {
   test.each<{
@@ -38,7 +43,10 @@ describe('Publish', () => {
       const [lib] = processedLibs;
 
       executeCommand(
-        `npx nx deploy ${lib.name} --registry=http://localhost:4873 --tag="e2e" --packageVersion=0.0.0`
+        deployCommand(lib.name, {
+          tag: 'e2e',
+          packageVersion: '0.0.0',
+        })
       );
 
       expect(() => {
@@ -60,12 +68,20 @@ describe('Publish', () => {
       const [uniqLibName] = processedLibs;
 
       executeCommand(
-        `npx nx deploy ${uniqLibName.name} --tag="e2e" --registry=http://localhost:4873 --packageVersion=0.0.0 --checkExisting="error"`
+        deployCommand(uniqLibName.name, {
+          tag: 'e2e',
+          packageVersion: '0.0.0',
+          checkExisting: 'error',
+        })
       );
 
       expect(() => {
         executeCommand(
-          `npx nx deploy ${uniqLibName.name} --tag="e2e" --registry=http://localhost:4873 --packageVersion=0.0.0 --checkExisting="error"`
+          deployCommand(uniqLibName.name, {
+            tag: 'e2e',
+            packageVersion: '0.0.0',
+            checkExisting: 'error',
+          })
         );
       }).toThrow();
 

--- a/packages/ngx-deploy-npm-e2e/src/utils/basic-setup.ts
+++ b/packages/ngx-deploy-npm-e2e/src/utils/basic-setup.ts
@@ -3,7 +3,7 @@ import { dirname, join } from 'path';
 import { execSync } from 'child_process';
 
 import { ProjectConfiguration } from '@nx/devkit';
-import { readJson } from '@nx/plugin/testing';
+import { readJson, uniq } from '@nx/plugin/testing';
 import { logger } from '@nx/devkit';
 
 import { InstallGeneratorOptions } from 'bikecoders/ngx-deploy-npm';
@@ -259,6 +259,7 @@ async function createMinimalLib(
       name: `@mock-domain/${projectName}`,
       description: 'Minimal LIb',
       version: '1.0.0',
+      main: './hello-world.js',
     };
 
     // Add nx configuration with targets when not using project.json
@@ -277,8 +278,9 @@ async function createMinimalLib(
  * @returns The directory where the test project was created
  */
 async function createTestProject() {
-  const projectName =
-    process.env.NGX_DEPLOY_NPM_E2E__PROJECT_NAME || 'test-project';
+  const projectName = `${
+    process.env.NGX_DEPLOY_NPM_E2E__PROJECT_NAME || 'test-project'
+  }-${uniq('')}`;
   const projectDirectory = join(process.cwd(), 'tmp', projectName);
 
   // Ensure projectDirectory is empty

--- a/packages/ngx-deploy-npm-e2e/src/utils/deploy-command.ts
+++ b/packages/ngx-deploy-npm-e2e/src/utils/deploy-command.ts
@@ -1,0 +1,40 @@
+export const E2E_REGISTRY = 'http://localhost:4873';
+
+export type DeployCommandOptions = {
+  registry?: string;
+  packageVersion?: string;
+  tag?: string;
+  checkExisting?: 'error' | 'warning' | 'skip';
+  checkTag?: boolean;
+  checkPublishReady?: 'probe' | 'publish';
+  distFolderPath?: string;
+  dryRun?: boolean;
+};
+
+export function deployCommand(
+  libName: string,
+  {
+    registry = E2E_REGISTRY,
+    packageVersion,
+    tag,
+    checkExisting,
+    checkTag,
+    checkPublishReady,
+    distFolderPath,
+    dryRun,
+  }: DeployCommandOptions = {}
+): string {
+  return [
+    `npx nx deploy ${libName}`,
+    `--registry=${registry}`,
+    packageVersion !== undefined ? `--packageVersion=${packageVersion}` : '',
+    tag ? `--tag="${tag}"` : '',
+    checkExisting ? `--checkExisting="${checkExisting}"` : '',
+    checkTag ? '--checkTag' : '',
+    checkPublishReady ? `--checkPublishReady="${checkPublishReady}"` : '',
+    distFolderPath ? `--distFolderPath="${distFolderPath}"` : '',
+    dryRun ? '--dryRun' : '',
+  ]
+    .filter(Boolean)
+    .join(' ');
+}

--- a/packages/ngx-deploy-npm-e2e/src/utils/index.ts
+++ b/packages/ngx-deploy-npm-e2e/src/utils/index.ts
@@ -5,3 +5,4 @@ export * from './get-nx-workspace-version';
 export * from './basic-setup';
 export * from './test-timeout';
 export * from './npm-env';
+export * from './deploy-command';

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.spec.ts
@@ -1,7 +1,9 @@
 import { logger } from '@nx/devkit';
+import * as fsPromises from 'node:fs/promises';
 import { DeployExecutorOptions } from '../schema';
 import { npmAccess } from '../../../core';
 import * as engine from './engine';
+import * as publishReadyChecks from './publish-ready-checks';
 import * as spawn from '../utils/spawn-async';
 import * as setPackage from '../utils/set-package-version';
 import { mockProjectDist, mockProjectRoot } from '../../../__mocks__/mocks';
@@ -699,6 +701,430 @@ describe('engine', () => {
         `${mockPackageJson.name}@${mockPackageJson.version}`,
         'version',
       ]);
+    });
+  });
+
+  describe('checkPublishReady', () => {
+    type CheckPublishReadySetupOptions = {
+      checkPublishReady?: DeployExecutorOptions['checkPublishReady'];
+      dryRun?: boolean;
+      readyChecksFail?: boolean;
+      mockReadyChecks?: boolean;
+      options?: Partial<Omit<DeployExecutorOptions, 'distFolderPath'>>;
+      mockPackageJson?: SetupOptions['mockPackageJson'];
+      spawnAsyncMock?: SetupOptions['spawnAsyncMock'];
+    };
+
+    function setupCheckPublishReady(opts: CheckPublishReadySetupOptions = {}) {
+      const {
+        checkPublishReady,
+        dryRun = false,
+        readyChecksFail = false,
+        mockReadyChecks = true,
+        options: extraOptions,
+        mockPackageJson,
+        spawnAsyncMock,
+      } = opts;
+
+      const runPublishReadyChecksSpy = jest.spyOn(
+        publishReadyChecks,
+        'runPublishReadyChecks'
+      );
+
+      if (mockReadyChecks) {
+        runPublishReadyChecksSpy.mockImplementation(() =>
+          readyChecksFail
+            ? Promise.reject(
+                new Error(
+                  'ngx-deploy-npm: Registry authentication failed for https://registry.npmjs.org/.'
+                )
+              )
+            : Promise.resolve()
+        );
+      }
+
+      const logDualDryRunWarningSpy = jest
+        .spyOn(publishReadyChecks, 'logDualDryRunWarning')
+        .mockImplementation(() => undefined);
+
+      const loggerInfoSpy = jest
+        .spyOn(logger, 'info')
+        .mockImplementation(() => undefined);
+
+      const base = setup({
+        ...(mockPackageJson ? { mockPackageJson } : {}),
+        ...(spawnAsyncMock ? { spawnAsyncMock } : {}),
+        options: {
+          ...defaultOption,
+          ...(checkPublishReady !== undefined ? { checkPublishReady } : {}),
+          dryRun,
+          ...extraOptions,
+        },
+      });
+
+      return {
+        ...base,
+        runPublishReadyChecksSpy,
+        logDualDryRunWarningSpy,
+        loggerInfoSpy,
+      };
+    }
+
+    afterEach(() => {
+      jest.restoreAllMocks();
+    });
+
+    it('should not run publish ready checks when checkPublishReady is unset', async () => {
+      const { absoluteDistFolderPath, options, runPublishReadyChecksSpy } =
+        setupCheckPublishReady({ checkPublishReady: undefined });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(runPublishReadyChecksSpy).not.toHaveBeenCalled();
+    });
+
+    it('should run publish ready checks before publish when mode is `publish`', async () => {
+      const { absoluteDistFolderPath, options, runPublishReadyChecksSpy } =
+        setupCheckPublishReady({ checkPublishReady: 'publish' });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(runPublishReadyChecksSpy).toHaveBeenCalledWith(
+        absoluteDistFolderPath,
+        options,
+        expect.objectContaining({ access: npmAccess.public })
+      );
+      expect(spawn.spawnAsync).toHaveBeenCalledWith('npm', [
+        'publish',
+        absoluteDistFolderPath,
+        '--access',
+        npmAccess.public,
+      ]);
+    });
+
+    it('should skip publish when mode is `probe` and deploy `--dry-run` is false', async () => {
+      const {
+        absoluteDistFolderPath,
+        options,
+        runPublishReadyChecksSpy,
+        loggerInfoSpy,
+      } = setupCheckPublishReady({ checkPublishReady: 'probe', dryRun: false });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(runPublishReadyChecksSpy).toHaveBeenCalled();
+      expect(loggerInfoSpy).toHaveBeenCalledWith(
+        expect.stringContaining('checkPublishReady=probe completed')
+      );
+      expect(spawn.spawnAsync).not.toHaveBeenCalledWith('npm', [
+        'publish',
+        absoluteDistFolderPath,
+        '--access',
+        npmAccess.public,
+      ]);
+    });
+
+    it('should continue to deploy dry-run publish when mode is `probe` and deploy `--dry-run` is true', async () => {
+      const {
+        absoluteDistFolderPath,
+        options,
+        runPublishReadyChecksSpy,
+        logDualDryRunWarningSpy,
+      } = setupCheckPublishReady({
+        checkPublishReady: 'probe',
+        dryRun: true,
+      });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(logDualDryRunWarningSpy).toHaveBeenCalledWith('probe');
+      expect(runPublishReadyChecksSpy).toHaveBeenCalled();
+      expect(spawn.spawnAsync).toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining([
+          'publish',
+          absoluteDistFolderPath,
+          '--dry-run',
+          '--access',
+          npmAccess.public,
+        ])
+      );
+    });
+
+    it('should warn about dual dry-run when publish mode and deploy `--dry-run` is true', async () => {
+      const { absoluteDistFolderPath, options, logDualDryRunWarningSpy } =
+        setupCheckPublishReady({
+          checkPublishReady: 'publish',
+          dryRun: true,
+        });
+
+      await engine.run(absoluteDistFolderPath, options);
+
+      expect(logDualDryRunWarningSpy).toHaveBeenCalledWith('publish');
+      expect(spawn.spawnAsync).toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining([
+          'publish',
+          absoluteDistFolderPath,
+          '--dry-run',
+          '--access',
+          npmAccess.public,
+        ])
+      );
+    });
+
+    it('should not publish when publish ready checks fail', async () => {
+      const { absoluteDistFolderPath, options } = setupCheckPublishReady({
+        checkPublishReady: 'publish',
+        readyChecksFail: true,
+      });
+
+      await expect(engine.run(absoluteDistFolderPath, options)).rejects.toThrow(
+        'Registry authentication failed'
+      );
+
+      expect(spawn.spawnAsync).not.toHaveBeenCalledWith(
+        'npm',
+        expect.arrayContaining(['publish', absoluteDistFolderPath])
+      );
+    });
+
+    describe('with packageVersion and checkExisting', () => {
+      const readyChecksPackageJson = {
+        name: '@test/package',
+        version: '1.0.0',
+        description: 'desc',
+        license: 'MIT',
+        repository: 'https://github.com/org/repo',
+        main: './index.js',
+      };
+
+      type IntegrationSetupOptions = {
+        checkPublishReady?: 'probe' | 'publish';
+        dryRun?: boolean;
+        packageVersion?: string;
+        checkExisting?: 'error';
+        packageExistsOnRegistry?: boolean;
+      };
+
+      function isProbePublishArgs(args: string[]) {
+        const tagIndex = args.indexOf('--tag');
+
+        return tagIndex !== -1 && args[tagIndex + 1] === 'verify';
+      }
+
+      function setupCheckPublishReadyIntegration(
+        opts: IntegrationSetupOptions = {}
+      ) {
+        const {
+          checkPublishReady = 'publish',
+          dryRun = false,
+          packageVersion,
+          checkExisting,
+          packageExistsOnRegistry = false,
+        } = opts;
+
+        let currentContent = JSON.stringify(readyChecksPackageJson);
+        const publishCalls: string[][] = [];
+        const viewCalls: string[][] = [];
+
+        const spawnAsyncMock: SetupOptions['spawnAsyncMock'] = (_, args) => {
+          const command = args ?? [];
+
+          if (command[0] === 'view') {
+            viewCalls.push(command);
+            return packageExistsOnRegistry
+              ? Promise.resolve()
+              : Promise.reject(new Error('not found'));
+          }
+
+          if (command[0] === 'publish') {
+            publishCalls.push(command);
+          }
+
+          return Promise.resolve();
+        };
+
+        const base = setupCheckPublishReady({
+          checkPublishReady,
+          dryRun,
+          mockReadyChecks: false,
+          mockPackageJson: readyChecksPackageJson,
+          spawnAsyncMock,
+          options: {
+            ...(packageVersion ? { packageVersion } : {}),
+            ...(checkExisting ? { checkExisting } : {}),
+          },
+        });
+
+        jest
+          .spyOn(fsPromises, 'stat')
+          .mockImplementation(() =>
+            Promise.resolve({ isDirectory: () => true } as Awaited<
+              ReturnType<typeof fsPromises.stat>
+            >)
+          );
+
+        jest
+          .spyOn(fileUtils, 'readFileAsync')
+          .mockImplementation(() => Promise.resolve(currentContent));
+
+        jest
+          .spyOn(fileUtils, 'writeFileAsync')
+          .mockImplementation((_, data) => {
+            currentContent = data as string;
+            return Promise.resolve();
+          });
+
+        jest
+          .spyOn(fileUtils, 'fileExists')
+          .mockImplementation(() => Promise.resolve(true));
+
+        const setPackageVersionSpy = jest.spyOn(
+          setPackage,
+          'setPackageVersion'
+        );
+
+        return {
+          ...base,
+          publishCalls,
+          viewCalls,
+          getCurrentContent: () => currentContent,
+          setPackageVersionSpy,
+          packageVersion,
+        };
+      }
+
+      it('should run `--check-publish-ready` then `--check-existing` against packageVersion when deploy `--dry-run` is true', async () => {
+        const {
+          absoluteDistFolderPath,
+          options,
+          packageVersion,
+          publishCalls,
+          viewCalls,
+          getCurrentContent,
+          runPublishReadyChecksSpy,
+        } = setupCheckPublishReadyIntegration({
+          checkPublishReady: 'publish',
+          packageVersion: '2.0.0',
+          dryRun: true,
+          checkExisting: 'error',
+          packageExistsOnRegistry: false,
+        });
+
+        await engine.run(absoluteDistFolderPath, options);
+
+        expect(runPublishReadyChecksSpy).toHaveBeenCalled();
+        expect(viewCalls).toContainEqual([
+          'view',
+          `@test/package@${packageVersion}`,
+          'version',
+        ]);
+        expect(publishCalls.some(args => isProbePublishArgs(args))).toBe(true);
+        expect(
+          publishCalls.some(
+            args => args.includes('--dry-run') && !isProbePublishArgs(args)
+          )
+        ).toBe(true);
+        expect(JSON.parse(getCurrentContent()).version).toBe('1.0.0');
+      });
+
+      it('should set packageVersion before checkPublishReady when not dry-run', async () => {
+        const {
+          absoluteDistFolderPath,
+          options,
+          setPackageVersionSpy,
+          runPublishReadyChecksSpy,
+        } = setupCheckPublishReadyIntegration({
+          checkPublishReady: 'publish',
+          packageVersion: '2.0.0',
+          checkExisting: 'error',
+          packageExistsOnRegistry: false,
+        });
+
+        await engine.run(absoluteDistFolderPath, options);
+
+        expect(setPackageVersionSpy).toHaveBeenCalledWith(
+          absoluteDistFolderPath,
+          '2.0.0'
+        );
+        expect(runPublishReadyChecksSpy).toHaveBeenCalled();
+      });
+
+      it('should throw when checkExisting is error and version exists after checkPublishReady', async () => {
+        const {
+          absoluteDistFolderPath,
+          options,
+          mockPackageJson,
+          publishCalls,
+          viewCalls,
+          runPublishReadyChecksSpy,
+        } = setupCheckPublishReadyIntegration({
+          checkPublishReady: 'publish',
+          checkExisting: 'error',
+          packageExistsOnRegistry: true,
+        });
+
+        await expect(() =>
+          engine.run(absoluteDistFolderPath, options)
+        ).rejects.toThrow(
+          `Package ${mockPackageJson.name}@${mockPackageJson.version} already exists in registry.`
+        );
+
+        expect(runPublishReadyChecksSpy).toHaveBeenCalled();
+        expect(viewCalls).toContainEqual([
+          'view',
+          `${mockPackageJson.name}@${mockPackageJson.version}`,
+          'version',
+        ]);
+        expect(publishCalls.every(args => isProbePublishArgs(args))).toBe(true);
+      });
+
+      it('should publish when checkExisting is error and version is not on registry after checkPublishReady', async () => {
+        const {
+          absoluteDistFolderPath,
+          options,
+          mockPackageJson,
+          publishCalls,
+          viewCalls,
+          runPublishReadyChecksSpy,
+        } = setupCheckPublishReadyIntegration({
+          checkPublishReady: 'publish',
+          checkExisting: 'error',
+          packageExistsOnRegistry: false,
+        });
+
+        await engine.run(absoluteDistFolderPath, options);
+
+        expect(runPublishReadyChecksSpy).toHaveBeenCalled();
+        expect(viewCalls).toContainEqual([
+          'view',
+          `${mockPackageJson.name}@${mockPackageJson.version}`,
+          'version',
+        ]);
+        expect(
+          publishCalls.some(
+            args =>
+              args[0] === 'publish' &&
+              args[1] === absoluteDistFolderPath &&
+              !isProbePublishArgs(args)
+          )
+        ).toBe(true);
+      });
+
+      it('should not run checkExisting when checkPublishReady is `probe` without deploy dryRun', async () => {
+        const { absoluteDistFolderPath, options, viewCalls, publishCalls } =
+          setupCheckPublishReadyIntegration({
+            checkPublishReady: 'probe',
+            checkExisting: 'error',
+            packageExistsOnRegistry: true,
+          });
+
+        await engine.run(absoluteDistFolderPath, options);
+
+        expect(viewCalls).toHaveLength(0);
+        expect(publishCalls.every(args => isProbePublishArgs(args))).toBe(true);
+      });
     });
   });
 

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/engine.ts
@@ -10,12 +10,21 @@ import {
   spawnAsyncMatchStdout,
 } from '../utils';
 import { DeployExecutorOptions } from '../schema';
+import {
+  DEFAULT_REGISTRY,
+  extractOnlyNPMOptions,
+  getOptionsStringArr,
+} from './npm-options';
+import {
+  isCheckPublishReadyEnabled,
+  logDualDryRunWarning,
+  runPublishReadyChecks,
+} from './publish-ready-checks';
 
 type PackageInfo = { name: string; version: string };
 type ExistingPackagePolicy = 'error' | 'warning' | 'skip';
 
 const NPM_PACK_TARBALL_SIZE_PATTERN = /"size":\s*(\d+)/;
-const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
 const DEFAULT_TAG = 'latest';
 
 async function checkIfPackageExists(
@@ -207,6 +216,21 @@ async function runDeploy(
 
     const npmOptions = extractOnlyNPMOptions(options);
 
+    if (isCheckPublishReadyEnabled(options.checkPublishReady)) {
+      if (options.dryRun) {
+        logDualDryRunWarning(options.checkPublishReady);
+      }
+
+      await runPublishReadyChecks(distFolderPath, options, npmOptions);
+
+      if (options.checkPublishReady === 'probe' && !options.dryRun) {
+        logger.info(
+          'ngx-deploy-npm: checkPublishReady=probe completed. Skipping publish.'
+        );
+        return;
+      }
+    }
+
     if (!(await ensurePublishAllowed(distFolderPath, options, npmOptions))) {
       return;
     }
@@ -242,60 +266,4 @@ export async function run(
   }
 
   await runDeploy(distFolderPath, options);
-}
-
-/**
- * Extract only the options that the `npm publish` command can process
- *
- * @param param0 All the options sent to deploy
- */
-function extractOnlyNPMOptions({
-  access,
-  tag,
-  otp,
-  dryRun,
-  registry,
-  provenance,
-  provenanceFile,
-  ignoreScripts,
-}: DeployExecutorOptions): NpmPublishOptions {
-  return {
-    access,
-    tag,
-    otp,
-    dryRun,
-    registry,
-    provenance,
-    provenanceFile,
-    ignoreScripts,
-  };
-}
-
-function toKebabCase(str: string) {
-  return str.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
-}
-
-function getOptionsStringArr(options: NpmPublishOptions): string[] {
-  return Object.entries(options).flatMap(([optKey, value]) => {
-    if (
-      value === undefined ||
-      value === null ||
-      value === false ||
-      value === ''
-    ) {
-      return [];
-    }
-
-    const cmdOption = `--${toKebabCase(optKey)}`;
-
-    if (typeof value === 'boolean') {
-      return [cmdOption];
-    }
-
-    if (typeof value === 'string' || typeof value === 'number') {
-      return [cmdOption, String(value)];
-    }
-
-    return [];
-  });
 }

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/npm-options.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/npm-options.ts
@@ -1,0 +1,74 @@
+import { DeployExecutorOptions } from '../schema';
+import { NpmPublishOptions } from '../utils';
+
+export const DEFAULT_REGISTRY = 'https://registry.npmjs.org/';
+
+export function formatRegistryLabel(registry?: string): string {
+  return registry ?? DEFAULT_REGISTRY;
+}
+
+export function extractOnlyNPMOptions({
+  access,
+  tag,
+  otp,
+  dryRun,
+  registry,
+  provenance,
+  provenanceFile,
+  ignoreScripts,
+}: DeployExecutorOptions): NpmPublishOptions {
+  return {
+    access,
+    tag,
+    otp,
+    dryRun,
+    registry,
+    provenance,
+    provenanceFile,
+    ignoreScripts,
+  };
+}
+
+function toKebabCase(str: string) {
+  return str.replace(/([a-z0-9]|(?=[A-Z]))([A-Z])/g, '$1-$2').toLowerCase();
+}
+
+export function getOptionsStringArr(options: NpmPublishOptions): string[] {
+  return Object.entries(options).flatMap(([optKey, value]) => {
+    if (
+      value === undefined ||
+      value === null ||
+      value === false ||
+      value === ''
+    ) {
+      return [];
+    }
+
+    const cmdOption = `--${toKebabCase(optKey)}`;
+
+    if (typeof value === 'boolean') {
+      return [cmdOption];
+    }
+
+    if (typeof value === 'string' || typeof value === 'number') {
+      return [cmdOption, String(value)];
+    }
+
+    return [];
+  });
+}
+
+export function getPublishProbeOptions(
+  npmOptions: NpmPublishOptions
+): string[] {
+  const probeOptions: NpmPublishOptions = {
+    access: npmOptions.access,
+    otp: npmOptions.otp,
+    registry: npmOptions.registry,
+    provenance: npmOptions.provenance,
+    provenanceFile: npmOptions.provenanceFile,
+    ignoreScripts: npmOptions.ignoreScripts,
+  };
+
+  return ['--dry-run', '--tag', 'verify', ...getOptionsStringArr(probeOptions)];
+}

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/publish-ready-checks.spec.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/publish-ready-checks.spec.ts
@@ -1,0 +1,357 @@
+import { logger } from '@nx/devkit';
+import { stat } from 'node:fs/promises';
+
+import * as fileUtils from '../../../utils';
+import { npmAccess } from '../../../core';
+import { DeployExecutorOptions } from '../schema';
+import * as spawn from '../utils/spawn-async';
+import * as setPackageVersion from '../utils/set-package-version';
+import {
+  buildProbeVersion,
+  collectPublishEntryPaths,
+  isCheckPublishReadyEnabled,
+  logDualDryRunWarning,
+  runPublishReadyChecks,
+  verifyRegistryAuth,
+} from './publish-ready-checks';
+import { NpmPublishOptions } from '../utils';
+
+jest.mock('node:fs/promises', () => ({
+  stat: jest.fn(),
+}));
+
+jest.mock('../../../utils', () => ({
+  __esModule: true,
+  ...jest.requireActual('../../../utils'),
+}));
+
+describe('publish-ready-checks', () => {
+  const distFolderPath = '/workspace/dist/libs/my-lib';
+  const defaultPackageJson = {
+    name: '@test/package',
+    version: '1.0.0',
+    description: 'desc',
+    license: 'MIT',
+    repository: 'https://github.com/org/repo',
+    main: './index.js',
+  };
+
+  const defaultNpmOptions: NpmPublishOptions = {
+    access: npmAccess.public,
+  };
+
+  type SetupOptions = {
+    isDirectory?: boolean;
+    packageJson?: Record<string, unknown>;
+    readFileError?: boolean;
+    entryFilesExist?: boolean;
+    whoamiFails?: boolean;
+    publishProbeFails?: boolean;
+    dryRun?: boolean;
+    registry?: string;
+    metadataIncomplete?: boolean;
+    checkPublishReady?: DeployExecutorOptions['checkPublishReady'];
+  };
+
+  function setup(opts: SetupOptions = {}) {
+    const {
+      isDirectory = true,
+      packageJson = defaultPackageJson,
+      readFileError = false,
+      entryFilesExist = true,
+      whoamiFails = false,
+      publishProbeFails = false,
+      dryRun = false,
+      registry,
+      metadataIncomplete = false,
+    } = opts;
+
+    const pkg = metadataIncomplete
+      ? { name: '@test/package', version: '1.0.0', main: './index.js' }
+      : packageJson;
+
+    jest.mocked(stat).mockImplementation(() => {
+      if (!isDirectory) {
+        return Promise.reject(new Error('not found'));
+      }
+
+      return Promise.resolve({ isDirectory: () => true } as Awaited<
+        ReturnType<typeof stat>
+      >);
+    });
+
+    jest.spyOn(fileUtils, 'readFileAsync').mockImplementation(() => {
+      if (readFileError) {
+        return Promise.reject(new Error('read failed'));
+      }
+
+      return Promise.resolve(JSON.stringify(pkg));
+    });
+
+    jest
+      .spyOn(fileUtils, 'fileExists')
+      .mockImplementation(() => Promise.resolve(entryFilesExist));
+
+    const spawnCalls: string[][] = [];
+    jest.spyOn(spawn, 'spawnAsync').mockImplementation((_cmd, args) => {
+      spawnCalls.push(args ?? []);
+
+      if (args?.[0] === 'whoami' && whoamiFails) {
+        return Promise.reject(new Error('not logged in'));
+      }
+
+      if (args?.[0] === 'publish' && publishProbeFails) {
+        return Promise.reject(new Error('publish failed'));
+      }
+
+      return Promise.resolve();
+    });
+
+    jest
+      .spyOn(setPackageVersion, 'withTemporaryPackageVersion')
+      .mockImplementation(async (_dir, _version, fn) => fn());
+
+    const loggerWarnSpy = metadataIncomplete
+      ? jest.spyOn(logger, 'warn').mockImplementation(() => undefined)
+      : undefined;
+
+    const options: DeployExecutorOptions = {
+      distFolderPath: 'dist/libs/my-lib',
+      access: npmAccess.public,
+      dryRun,
+      registry,
+      ...(opts.checkPublishReady !== undefined
+        ? { checkPublishReady: opts.checkPublishReady }
+        : { checkPublishReady: 'probe' }),
+    };
+
+    return {
+      distFolderPath,
+      options,
+      npmOptions: { ...defaultNpmOptions, registry, dryRun },
+      spawnCalls,
+      loggerWarnSpy,
+    };
+  }
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('isCheckPublishReadyEnabled', () => {
+    it('should return true for probe and publish', () => {
+      expect(isCheckPublishReadyEnabled('probe')).toBe(true);
+      expect(isCheckPublishReadyEnabled('publish')).toBe(true);
+    });
+
+    it('should return false when unset', () => {
+      expect(isCheckPublishReadyEnabled(undefined)).toBe(false);
+    });
+  });
+
+  describe('logDualDryRunWarning', () => {
+    function setupLogDualDryRunWarning() {
+      const loggerWarnSpy = jest
+        .spyOn(logger, 'warn')
+        .mockImplementation(() => undefined);
+
+      return { loggerWarnSpy };
+    }
+
+    it('should log warning about two publish dry-runs', () => {
+      const { loggerWarnSpy } = setupLogDualDryRunWarning();
+
+      logDualDryRunWarning('probe');
+
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('two npm publish --dry-run')
+      );
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('disposable')
+      );
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('package.json')
+      );
+    });
+  });
+
+  describe('buildProbeVersion', () => {
+    function setupBuildProbeVersion(opts: { dateNow?: number } = {}) {
+      const { dateNow = 1_700_000_000_000 } = opts;
+
+      jest.spyOn(Date, 'now').mockReturnValue(dateNow);
+
+      return { dateNow };
+    }
+
+    it('should append verify prerelease with timestamp', () => {
+      const { dateNow } = setupBuildProbeVersion();
+
+      expect(buildProbeVersion('2.3.4')).toBe(`2.3.4-verify.${dateNow}`);
+    });
+  });
+
+  describe('collectPublishEntryPaths', () => {
+    it('should collect main and nested exports paths', () => {
+      const paths = collectPublishEntryPaths({
+        main: './index.js',
+        exports: {
+          '.': { import: './index.mjs', default: './index.js' },
+        },
+      });
+
+      expect(paths).toEqual(
+        expect.arrayContaining([
+          { field: 'main', relativePath: './index.js' },
+          { field: 'exports', relativePath: './index.mjs' },
+        ])
+      );
+    });
+  });
+
+  describe('verifyRegistryAuth', () => {
+    it('should call npm whoami with registry when provided', async () => {
+      const { spawnCalls } = setup({ registry: 'http://localhost:4873' });
+
+      await verifyRegistryAuth('http://localhost:4873');
+
+      expect(spawnCalls[0]).toEqual([
+        'whoami',
+        '--registry',
+        'http://localhost:4873',
+      ]);
+    });
+
+    it('should throw auth-specific error when whoami fails', async () => {
+      const { spawnCalls } = setup({ whoamiFails: true });
+
+      await expect(verifyRegistryAuth()).rejects.toThrow(
+        'ngx-deploy-npm: Registry authentication failed'
+      );
+
+      expect(spawnCalls.some(args => args[0] === 'whoami')).toBe(true);
+    });
+  });
+
+  describe('runPublishReadyChecks', () => {
+    it('should pass when all checks succeed and run publish probe', async () => {
+      const { distFolderPath, options, npmOptions, spawnCalls } = setup();
+
+      await runPublishReadyChecks(distFolderPath, options, npmOptions);
+
+      expect(spawnCalls.some(args => args[0] === 'whoami')).toBe(true);
+      const publishCall = spawnCalls.find(args => args[0] === 'publish');
+      expect(publishCall).toEqual(
+        expect.arrayContaining([
+          'publish',
+          distFolderPath,
+          '--dry-run',
+          '--tag',
+          'verify',
+          '--access',
+          npmAccess.public,
+        ])
+      );
+      expect(
+        setPackageVersion.withTemporaryPackageVersion
+      ).toHaveBeenCalledWith(
+        distFolderPath,
+        expect.stringMatching(/^1\.0\.0-verify\.\d+$/),
+        expect.any(Function)
+      );
+    });
+
+    it('should throw when dist folder is missing', async () => {
+      const { distFolderPath, options, npmOptions } = setup({
+        isDirectory: false,
+      });
+
+      await expect(
+        runPublishReadyChecks(distFolderPath, options, npmOptions)
+      ).rejects.toThrow('Publish dist folder not found');
+      expect(spawn.spawnAsync).not.toHaveBeenCalled();
+    });
+
+    it('should throw when package.json is invalid', async () => {
+      const { distFolderPath, options, npmOptions } = setup({
+        readFileError: true,
+      });
+
+      await expect(
+        runPublishReadyChecks(distFolderPath, options, npmOptions)
+      ).rejects.toThrow('package.json not found or invalid');
+    });
+
+    it('should throw when name is missing', async () => {
+      const { distFolderPath, options, npmOptions } = setup({
+        packageJson: { version: '1.0.0', main: './index.js' },
+      });
+
+      await expect(
+        runPublishReadyChecks(distFolderPath, options, npmOptions)
+      ).rejects.toThrow('missing required field "name"');
+    });
+
+    it('should throw when entry file is missing', async () => {
+      const { distFolderPath, options, npmOptions } = setup({
+        entryFilesExist: false,
+      });
+
+      await expect(
+        runPublishReadyChecks(distFolderPath, options, npmOptions)
+      ).rejects.toThrow('Publish entry file missing');
+    });
+
+    it('should warn on missing metadata fields', async () => {
+      const { distFolderPath, options, npmOptions, loggerWarnSpy } = setup({
+        metadataIncomplete: true,
+      });
+
+      await runPublishReadyChecks(distFolderPath, options, npmOptions);
+
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('description')
+      );
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('license')
+      );
+      expect(loggerWarnSpy).toHaveBeenCalledWith(
+        expect.stringContaining('repository')
+      );
+    });
+
+    it('should run publish probe when deploy dryRun is true', async () => {
+      const { distFolderPath, options, npmOptions, spawnCalls } = setup({
+        dryRun: true,
+        checkPublishReady: 'publish',
+      });
+
+      await runPublishReadyChecks(distFolderPath, options, npmOptions);
+
+      expect(spawnCalls.some(args => args[0] === 'whoami')).toBe(true);
+      expect(spawnCalls.some(args => args[0] === 'publish')).toBe(true);
+    });
+
+    it('should no-op when checkPublishReady is unset', async () => {
+      const { distFolderPath, npmOptions } = setup();
+      const options: DeployExecutorOptions = {
+        distFolderPath: 'dist/libs/my-lib',
+        access: npmAccess.public,
+      };
+
+      await runPublishReadyChecks(distFolderPath, options, npmOptions);
+
+      expect(spawn.spawnAsync).not.toHaveBeenCalled();
+    });
+
+    it('should throw probe-specific error when publish dry-run fails', async () => {
+      const { distFolderPath, options, npmOptions } = setup({
+        publishProbeFails: true,
+      });
+
+      await expect(
+        runPublishReadyChecks(distFolderPath, options, npmOptions)
+      ).rejects.toThrow('npm publish --dry-run failed');
+    });
+  });
+});

--- a/packages/ngx-deploy-npm/src/executors/deploy/engine/publish-ready-checks.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/engine/publish-ready-checks.ts
@@ -1,0 +1,231 @@
+import { logger } from '@nx/devkit';
+import { stat } from 'node:fs/promises';
+import * as path from 'node:path';
+
+import * as fileUtils from '../../../utils';
+import { DeployExecutorOptions } from '../schema';
+import {
+  NpmPublishOptions,
+  spawnAsync,
+  withTemporaryPackageVersion,
+} from '../utils';
+import { formatRegistryLabel, getPublishProbeOptions } from './npm-options';
+
+const PUBLISH_ENTRY_PATH_PATTERN = /^\.\//;
+
+type PackageJsonForReadyCheck = {
+  name?: string;
+  version?: string;
+  description?: string;
+  license?: string;
+  repository?: string | { type?: string; url?: string };
+  main?: string;
+  module?: string;
+  types?: string;
+  typings?: string;
+  exports?: string | Record<string, unknown>;
+};
+
+export function buildProbeVersion(version: string): string {
+  return `${version}-verify.${Date.now()}`;
+}
+
+export function isCheckPublishReadyEnabled(
+  mode: DeployExecutorOptions['checkPublishReady']
+): mode is 'probe' | 'publish' {
+  return mode === 'probe' || mode === 'publish';
+}
+
+export function logDualDryRunWarning(mode: 'probe' | 'publish'): void {
+  logger.warn(
+    `ngx-deploy-npm: checkPublishReady="${mode}" with deploy --dry-run will run two npm publish --dry-run calls.`
+  );
+  logger.warn(
+    'First: registry probe with a disposable {version}-verify.{timestamp} (dist-tag verify).'
+  );
+  logger.warn(
+    'Second: deploy dry-run using the version in dist package.json (may fail if that version already exists on the registry).'
+  );
+}
+
+function collectExportEntryPaths(
+  exportsValue: Record<string, unknown>,
+  paths: Set<string>
+): void {
+  for (const value of Object.values(exportsValue)) {
+    if (typeof value === 'string' && PUBLISH_ENTRY_PATH_PATTERN.test(value)) {
+      paths.add(value);
+    } else if (value && typeof value === 'object' && !Array.isArray(value)) {
+      collectExportEntryPaths(value as Record<string, unknown>, paths);
+    }
+  }
+}
+
+export function collectPublishEntryPaths(
+  packageJson: PackageJsonForReadyCheck
+): { field: string; relativePath: string }[] {
+  const paths = new Set<string>();
+  const fieldByPath = new Map<string, string>();
+
+  const addPath = (field: string, relativePath: string) => {
+    if (!PUBLISH_ENTRY_PATH_PATTERN.test(relativePath)) {
+      return;
+    }
+
+    paths.add(relativePath);
+    if (!fieldByPath.has(relativePath)) {
+      fieldByPath.set(relativePath, field);
+    }
+  };
+
+  for (const field of ['main', 'module', 'types', 'typings'] as const) {
+    const value = packageJson[field];
+    if (typeof value === 'string') {
+      addPath(field, value);
+    }
+  }
+
+  if (typeof packageJson.exports === 'string') {
+    addPath('exports', packageJson.exports);
+  } else if (packageJson.exports && typeof packageJson.exports === 'object') {
+    collectExportEntryPaths(packageJson.exports, paths);
+    for (const relativePath of paths) {
+      if (!fieldByPath.has(relativePath)) {
+        fieldByPath.set(relativePath, 'exports');
+      }
+    }
+  }
+
+  return [...paths].map(relativePath => ({
+    field: fieldByPath.get(relativePath) ?? 'exports',
+    relativePath,
+  }));
+}
+
+async function readDistPackageJson(
+  distFolderPath: string
+): Promise<PackageJsonForReadyCheck> {
+  const packageJsonPath = path.join(distFolderPath, 'package.json');
+
+  try {
+    const packageContent = await fileUtils.readFileAsync(packageJsonPath, {
+      encoding: 'utf8',
+    });
+
+    return JSON.parse(packageContent) as PackageJsonForReadyCheck;
+  } catch {
+    throw new Error(
+      `Publish package.json not found or invalid at "${packageJsonPath}".`
+    );
+  }
+}
+
+async function runStaticPublishReadyChecks(
+  distFolderPath: string
+): Promise<PackageJsonForReadyCheck> {
+  try {
+    const distStat = await stat(distFolderPath);
+    if (!distStat.isDirectory()) {
+      throw new Error('not a directory');
+    }
+  } catch {
+    throw new Error(
+      `Publish dist folder not found at "${distFolderPath}". Build the library first (e.g. nx build <project>).`
+    );
+  }
+
+  const packageJson = await readDistPackageJson(distFolderPath);
+
+  if (!packageJson.name) {
+    throw new Error('Publish package.json is missing required field "name".');
+  }
+
+  if (!packageJson.version) {
+    throw new Error(
+      'Publish package.json is missing required field "version".'
+    );
+  }
+
+  if (!packageJson.description) {
+    logger.warn(
+      'Publish package.json is missing recommended field "description".'
+    );
+  }
+
+  if (!packageJson.license) {
+    logger.warn('Publish package.json is missing recommended field "license".');
+  }
+
+  if (!packageJson.repository) {
+    logger.warn(
+      'Publish package.json is missing recommended field "repository".'
+    );
+  }
+
+  for (const { field, relativePath } of collectPublishEntryPaths(packageJson)) {
+    const entryPath = path.join(distFolderPath, relativePath);
+    if (!(await fileUtils.fileExists(entryPath))) {
+      throw new Error(
+        `Publish entry file missing: "${relativePath}" (from package.json "${field}").`
+      );
+    }
+  }
+
+  return packageJson;
+}
+
+export async function verifyRegistryAuth(registry?: string): Promise<void> {
+  const args = ['whoami'];
+  if (registry) {
+    args.push('--registry', registry);
+  }
+
+  try {
+    await spawnAsync('npm', args);
+  } catch {
+    throw new Error(
+      `ngx-deploy-npm: Registry authentication failed for ${formatRegistryLabel(
+        registry
+      )}. Run npm whoami locally, set NODE_AUTH_TOKEN / .npmrc, or configure npm OIDC trusted publishing.`
+    );
+  }
+}
+
+async function runPublishProbe(
+  distFolderPath: string,
+  packageJson: PackageJsonForReadyCheck,
+  npmOptions: NpmPublishOptions
+): Promise<void> {
+  const probeVersion = buildProbeVersion(packageJson.version as string);
+  const registry = formatRegistryLabel(npmOptions.registry);
+
+  try {
+    await withTemporaryPackageVersion(distFolderPath, probeVersion, () =>
+      spawnAsync('npm', [
+        'publish',
+        distFolderPath,
+        ...getPublishProbeOptions(npmOptions),
+      ])
+    );
+  } catch {
+    throw new Error(
+      `ngx-deploy-npm: npm publish --dry-run failed for ${registry}. Check package.json, dist contents, access/provenance options, and registry permissions.`
+    );
+  }
+}
+
+export async function runPublishReadyChecks(
+  distFolderPath: string,
+  options: DeployExecutorOptions,
+  npmOptions: NpmPublishOptions
+): Promise<void> {
+  if (!isCheckPublishReadyEnabled(options.checkPublishReady)) {
+    return;
+  }
+
+  const packageJson = await runStaticPublishReadyChecks(distFolderPath);
+
+  await verifyRegistryAuth(options.registry);
+
+  await runPublishProbe(distFolderPath, packageJson, npmOptions);
+}

--- a/packages/ngx-deploy-npm/src/executors/deploy/schema.d.ts
+++ b/packages/ngx-deploy-npm/src/executors/deploy/schema.d.ts
@@ -47,4 +47,14 @@ export interface DeployExecutorOptions {
    * When true, only run the checkExisting duplicate version check when publishing to a non-latest tag
    */
   checkTag?: boolean;
+  /**
+   * Pre-publish validation mode. Both values run static checks, npm whoami, and a registry
+   * probe (npm publish --dry-run with a disposable {version}-verify.{timestamp}).
+   * - `probe`: exit after validation (typical pre-bump CI).
+   * - `publish`: continue to checkExisting and npm publish after validation.
+   * With deploy `dryRun`, both values log a warning and run a second npm publish --dry-run
+   * using the version in dist package.json (in addition to the probe dry-run).
+   * Complements checkExisting; does not replace it.
+   */
+  checkPublishReady?: 'probe' | 'publish';
 }

--- a/packages/ngx-deploy-npm/src/executors/deploy/schema.json
+++ b/packages/ngx-deploy-npm/src/executors/deploy/schema.json
@@ -60,6 +60,11 @@
       "type": "boolean",
       "description": "When true, only run the checkExisting duplicate version check when publishing to a non-latest tag",
       "default": false
+    },
+    "checkPublishReady": {
+      "type": "string",
+      "description": "Pre-publish validation: 'probe' exits after validation; 'publish' continues to npm publish. With deploy dryRun, both run a second publish dry-run using package.json version.",
+      "enum": ["probe", "publish"]
     }
   },
   "required": ["distFolderPath"]

--- a/tools/scripts/start-local-registry.ts
+++ b/tools/scripts/start-local-registry.ts
@@ -4,6 +4,95 @@
  */
 import { startLocalRegistry } from '@nx/js/plugins/jest/local-registry';
 import { execSync } from 'child_process';
+import { existsSync, unlinkSync } from 'fs';
+import { join } from 'path';
+
+const REGISTRY = 'http://localhost:4873';
+const E2E_USER = 'e2euser';
+const E2E_PASS = 'e2e';
+const E2E_EMAIL = 'e2e@test.local';
+const HTPASSWD_PATH = join(process.cwd(), '.verdaccio', 'htpasswd');
+
+function deleteHtpasswdIfExists(): void {
+  if (existsSync(HTPASSWD_PATH)) {
+    unlinkSync(HTPASSWD_PATH);
+  }
+}
+
+function setRegistryAuthToken(registry: string, token: string): void {
+  const { hostname, port } = new URL(registry);
+
+  execSync(
+    `npm config set //${hostname}:${port}/:_authToken "${token}" --ws=false`,
+    { windowsHide: true }
+  );
+}
+
+async function registerVerdaccioUser(registry: string): Promise<string> {
+  const response = await fetch(
+    `${registry}/-/user/org.couchdb.user:${E2E_USER}`,
+    {
+      method: 'PUT',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        name: E2E_USER,
+        password: E2E_PASS,
+        email: E2E_EMAIL,
+      }),
+    }
+  );
+
+  const body = (await response.json()) as { token?: string; error?: string };
+
+  if (!response.ok || !body.token) {
+    throw new Error(
+      `Failed to register Verdaccio user "${E2E_USER}": ${
+        body.error ?? response.statusText
+      }`
+    );
+  }
+
+  return body.token;
+}
+
+function verifyNpmWhoami(registry: string, expectedUser: string): void {
+  let whoamiUser: string;
+
+  try {
+    whoamiUser = execSync(`npm whoami --registry=${registry}`, {
+      encoding: 'utf-8',
+      env: process.env,
+      windowsHide: true,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    }).trim();
+  } catch (error) {
+    const execError = error as {
+      stdout?: string;
+      stderr?: string;
+      message?: string;
+    };
+
+    throw new Error(
+      `npm whoami verification failed for "${expectedUser}": ${
+        execError.stderr || execError.stdout || execError.message
+      }`
+    );
+  }
+
+  if (whoamiUser !== expectedUser) {
+    throw new Error(
+      `npm whoami verification failed for "${expectedUser}": got "${whoamiUser}"`
+    );
+  }
+}
+
+async function ensureVerdaccioUser(registry: string): Promise<void> {
+  const token = await registerVerdaccioUser(registry);
+  setRegistryAuthToken(registry, token);
+  verifyNpmWhoami(registry, E2E_USER);
+
+  console.log(`Registered Verdaccio user "${E2E_USER}" for npm whoami`);
+}
 
 export default async () => {
   // local registry target to run
@@ -11,13 +100,17 @@ export default async () => {
   // storage folder for the local registry
   const storage = './tmp/local-registry/storage';
 
+  deleteHtpasswdIfExists();
+
   globalThis.stopLocalRegistry = await startLocalRegistry({
     localRegistryTarget,
     storage,
     verbose: false,
   });
 
+  await ensureVerdaccioUser(REGISTRY);
+
   execSync(
-    'npx nx deploy:without-build ngx-deploy-npm --registry=http://localhost:4873 --packageVersion=0.0.0 --tag e2e'
+    `npx nx deploy:without-build ngx-deploy-npm --registry=${REGISTRY} --packageVersion=0.0.0 --tag e2e`
   );
 };


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes/features)
- [x] Docs have been added/updated (for bug fixes/features)

## What is the current behavior?

Deploy runs `checkExisting` (optional) and `npm publish` with no built-in pre-flight checks for dist layout, registry auth, or a publish dry-run before the real publish.

Issue Number: N/A

## What is the new behavior?

Adds optional deploy flag `--check-publish-ready` with two modes:

| Mode | Behavior |
|------|----------|
| `probe` | Static checks (dist, `package.json`, entry files, metadata warnings), `npm whoami`, then `npm publish --dry-run` with disposable `{version}-verify.{timestamp}` and dist-tag `verify`. Exits without publishing (pre-bump CI). |
| `publish` | Same validation, then continues to `checkExisting` and real `npm publish`. |

Also includes:

- Shared e2e `deployCommand` helper and `E2E_REGISTRY` for all deploy/smoke specs
- Minimal e2e lib `main` entry in setup for entry-file validation
- Single e2e spec covering probe on an already-published version, missing dist failure, and publish mode

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Example usage:

```bash
# Pre-bump verify (no upload)
nx deploy my-lib --check-publish-ready=probe

# Release gate before publish
nx deploy my-lib --check-publish-ready=publish
```