### PR TITLE
fix(ci): use GIT_BOT_TOKEN for GitHub release in publishment

### DIFF
--- a/.github/workflows/publishment.yml
+++ b/.github/workflows/publishment.yml
@@ -64,7 +64,7 @@ jobs:
       - name: Version and Publishment
         run: npx nx version ngx-deploy-npm
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_BOT_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GIT_BOT_TOKEN }}
 
       - name: Tag last-release
         run: git tag --force last-release


### PR DESCRIPTION
## Summary

- Fix typo in `publishment.yml`: the Version step referenced `secrets.GITHUB_BOT_TOKEN`, which does not exist in this repo.
- Use `secrets.GIT_BOT_TOKEN` instead, matching checkout, push, and the rest of the release job.
- Restores auth for `@jscutlery/semver:github` (`gh release create`) after npm publish — `gh` accepts `GITHUB_TOKEN` when set to a non-empty value.

## Test plan

- [ ] Merge to `main` and approve the next publishment run (or re-run release for the failed version if needed)
- [ ] Confirm `gh release create` succeeds in the **Version and Publishment** step
- [ ] Confirm GitHub release appears for the published tag